### PR TITLE
Add online uncertainty visualization for SystemDynamicsEnsemble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,13 @@ docker/artifacts/
 # Doc Outputs
 **/docs/_build/*
 **/generated/*
+*.pt
+*.pth
+*.png
+*.ckpt
+*.csv
+logs/
+outputs/
 
 # Isaac-Sim packman
 _isaac_sim*
@@ -72,3 +79,9 @@ tests/
 
 # Docker history
 .isaac-lab-docker-history
+
+# Large data / checkpoints (not tracked in git)
+*.zip
+*.bin
+*.npz
+.claude/

--- a/UNCERTAINTY_VIZ.md
+++ b/UNCERTAINTY_VIZ.md
@@ -1,0 +1,196 @@
+# Uncertainty Visualization — Guide de lecture
+
+Script : `run_uncertainty_viz.py`  
+Checkpoint : `checkpoints_paws/model_2000_pretrain.pt`  
+Données : `utils_paws/walk_spot2.npz`
+
+---
+
+## 1. Le modèle : SystemDynamicsEnsemble
+
+Le world model est un **GRU ensembliste** entraîné à prédire le prochain état du robot Go2 à partir de son historique d'états et d'actions.
+
+```
+Input à chaque step :
+  état normalisé   s_t  ∈ ℝ^45
+  action normalisée a_t  ∈ ℝ^12
+  → concaténés en x_t ∈ ℝ^57
+
+Backbone partagé (identique pour toutes les têtes) :
+  GRU  :  57 → hidden 256,  2 couches
+  (les poids du GRU sont communs à toutes les têtes)
+
+5 têtes indépendantes (h0 … h4), chacune :
+  MLP mean    :  256 → 128 → 45   →  μ_e(t)   moyenne prédite du prochain état
+  MLP logstd  :  256 → 128 → 45   →  σ_e(t)   écart-type aléatoire par dimension
+  (les poids des MLP sont différents par tête)
+```
+
+### Pourquoi un ensemble de têtes ?
+
+Chaque tête a été initialisée différemment et entraînée simultanément.
+Si elles prédisent des valeurs proches → le modèle est **confiant**.
+Si elles divergent → le modèle est **incertain** (état peu vu à l'entraînement).
+
+---
+
+## 2. Les deux types d'incertitude
+
+### 2.1 Incertitude épistémique (bleue)
+
+> "Ce que le modèle ne sait pas."
+
+Calculée comme **l'écart-type des moyennes prédites à travers les 5 têtes**, sommé sur les 45 dimensions d'état :
+
+```
+σ_epi(t) = Σ_d  std_{e=0..4}( μ_e(t, d) )
+```
+
+| Valeur | Interprétation |
+|--------|----------------|
+| Faible | Le robot est dans un état bien couvert par les données d'entraînement |
+| Élevée | État inhabituel, hors distribution, ou transition physique complexe |
+
+**Peut être réduite** en ajoutant plus de données d'entraînement diversifiées.
+
+---
+
+### 2.2 Incertitude aléatoire (rouge)
+
+> "Le bruit irréductible du système physique."
+
+Calculée comme la **moyenne des écarts-types prédits par chaque tête**, sommé sur les 45 dimensions :
+
+```
+σ_ale(t) = Σ_d  mean_{e=0..4}( σ_e(t, d) )
+```
+
+| Valeur | Interprétation |
+|--------|----------------|
+| Faible | La dynamique est localement prévisible |
+| Élevée | Contact, glissement, perturbation externe — le futur est intrinsèquement variable |
+
+**Ne peut pas être réduite** avec plus de données : c'est le bruit du monde réel.
+
+---
+
+## 3. L'espace d'état (45 dimensions)
+
+| Indices | Variable | Unité | Description |
+|---------|----------|-------|-------------|
+| 0–2     | `vx vy vz`   | m/s   | Vitesse linéaire de la base |
+| 3–5     | `wx wy wz`   | rad/s | Vitesse angulaire de la base |
+| 6–8     | `gx gy gz`   | —     | Gravité projetée dans le repère corps (≈ orientation) |
+| 9–20    | `q0 … q11`   | rad   | Positions articulaires (12 joints) |
+| 21–32   | `dq0 … dq11` | rad/s | Vitesses articulaires |
+| 33–44   | `τ0 … τ11`   | Nm    | Couples articulaires |
+
+Ordre des joints : FR_Hip, FR_Thigh, FR_Calf, FL_Hip, FL_Thigh, FL_Calf, RR_Hip, RR_Thigh, RR_Calf, RL_Hip, RL_Thigh, RL_Calf.
+
+Les données sont **normalisées** avant passage dans le modèle :
+```
+s_norm = (s_raw - mean) / std
+```
+avec `mean[8] = -1.0` (gravité z au repos), `std` typique : 0.5 m/s pour les vitesses, 0.2 rad pour les positions.
+
+---
+
+## 4. Lecture de la figure (3 lignes × 6 colonnes)
+
+```
+┌─────────────────┬─────────────────┬─────────────────┐
+│ Histogramme     │ Histogramme     │ Série temporelle │  ← Ligne 1
+│ σ_épistémique   │ σ_aléatoire     │ des deux unc.    │
+├────┬────┬────┬──┴─┬────┬──────────┴──────────────────┤
+│ μ  │ μ  │ μ  │ μ  │ μ  │ μ                           │  ← Ligne 2
+│ vx │ vy │ vz │ wx │ wy │ wz  (6 premières dims)       │
+├────┬────┬────┬────┬────┬─────────────────────────────┤
+│ σ  │ σ  │ σ  │ σ  │ σ  │ σ                           │  ← Ligne 3
+│ vx │ vy │ vz │ wx │ wy │ wz  (mêmes dims)             │
+└────┴────┴────┴────┴────┴─────────────────────────────┘
+```
+
+---
+
+### Ligne 1 — Vue globale
+
+#### Histogramme σ_épistémique (gauche)
+- Axe X : valeur de l'incertitude épistémique (somme sur 45 dims)
+- Hauteur de barre : nombre de timesteps à cette valeur
+- **Queue à droite** = quelques moments où le modèle est très incertain
+- Distribution concentrée = comportement homogène sur tout le rollout
+
+#### Histogramme σ_aléatoire (centre)
+- Même lecture que ci-dessus pour l'incertitude aléatoire
+- Généralement plus concentré (bruit physique relativement constant)
+
+#### Séries temporelles (droite)
+- Axe X : numéro de step (après les 32 steps de warm-up GRU)
+- Axe Y : valeur d'incertitude
+- **Pics bleus** = instants où le robot est dans un état hors distribution
+- **Pics rouges** = instants physiquement bruités (atterrissages, glissements)
+- Les deux pics coïncident souvent mais pas toujours
+
+---
+
+### Ligne 2 — Moyennes prédites μ par tête
+
+Chaque sous-plot correspond à une dimension de l'état (vx, vy, vz, wx, wy, wz).
+
+- **5 courbes colorées** (h0–h4) = la prédiction du prochain état par chaque tête
+- **Courbes confondues** = modèle confiant sur cette dimension
+- **Courbes qui s'écartent** = incertitude épistémique élevée sur cette dimension
+- L'axe Y est en **espace normalisé** (sans unité) : 0 ≈ valeur moyenne, ±1 ≈ ±1 écart-type
+
+---
+
+### Ligne 3 — Écarts-types prédits σ par tête
+
+Même layout que la ligne 2, mais chaque courbe montre **l'incertitude aléatoire de la tête** sur cette dimension.
+
+- **σ élevé** sur une dim = la tête dit "même avec la même entrée, la sortie est variable"
+- Les 5 têtes ont typiquement des σ similaires (même backbone GRU partagé)
+- Un écart entre têtes sur σ indique que les têtes ont appris des "niveaux de confiance" différents pour cette dimension
+
+---
+
+## 5. Warmup GRU
+
+Le GRU a besoin de **32 steps d'historique** pour initialiser son état caché avant de faire des prédictions fiables. Le script consomme donc les 32 premiers frames pour le warm-up et commence la visualisation à `t = 32`.
+
+Sur 3 077 frames totales → **3 045 frames visualisées**.
+
+---
+
+## 6. Ce que l'incertitude révèle sur la marche
+
+| Observation dans les plots | Cause probable |
+|---------------------------|----------------|
+| Pic d'incertitude épistémique | Transition de foulée, changement de vitesse, sol irrégulier |
+| σ_aléatoire élevé sur τ (couples) | Contacts pied-sol avec glissement ou rebond |
+| σ_aléatoire élevé sur dq (vitesses) | Oscillations articulaires rapides après contact |
+| Têtes très divergentes sur vx/vy | Accélération ou décélération peu vue à l'entraînement |
+| Incertitude globalement faible | Phase de marche stable et régulière |
+
+---
+
+## 7. Commande
+
+```powershell
+cd "C:\Users\tjga9\Documents\Tomas\EPFL\AI Team\RWM"
+& "C:\Users\tjga9\anaconda3\python.exe" run_uncertainty_viz.py `
+    --checkpoint checkpoints_paws/model_2000_pretrain.pt `
+    --data       utils_paws/walk_spot2.npz `
+    --device     cpu `
+    --pause      0.05 `
+    --update_every 10
+```
+
+### Paramètres utiles
+
+| Paramètre | Défaut | Effet |
+|-----------|--------|-------|
+| `--update_every N` | 10 | Redessine tous les N steps (plus grand = plus rapide) |
+| `--pause P` | 0.05 | Secondes d'attente entre chaque frame |
+| `--history H` | 32 | Taille de la fenêtre de warm-up GRU |
+| `--device cuda` | cpu | Utilise le GPU si disponible |

--- a/robotic_world_model/.dockerignore
+++ b/robotic_world_model/.dockerignore
@@ -1,0 +1,28 @@
+# ignore .git related folders
+.git/
+.github/
+.gitignore
+# ignore docs
+docs/
+# copy in licenses folder to the container
+!docs/licenses/
+# ignore logs
+**/logs/
+**/runs/
+**/output/*
+**/outputs/*
+**/videos/*
+**/wandb/*
+*.tmp
+# ignore docker
+docker/cluster/exports/
+docker/.container.cfg
+# ignore recordings
+recordings/
+# ignore __pycache__
+**/__pycache__/
+**/*.egg-info/
+# ignore isaac sim symlink
+_isaac_sim?
+# Docker history
+docker/.isaac-lab-docker-history

--- a/robotic_world_model/.flake8
+++ b/robotic_world_model/.flake8
@@ -1,0 +1,24 @@
+# copied from https://github.com/isaac-sim/IsaacLab/blob/main/.flake8
+
+[flake8]
+show-source=True
+statistics=True
+per-file-ignores=*/__init__.py:F401
+# E402: Module level import not at top of file
+# E501: Line too long
+# W503: Line break before binary operator
+# E203: Whitespace before ':' -> conflicts with black
+# D401: First line should be in imperative mood
+# R504: Unnecessary variable assignment before return statement.
+# R505: Unnecessary elif after return statement
+# SIM102: Use a single if-statement instead of nested if-statements
+# SIM117: Merge with statements for context managers that have same scope.
+ignore=E402,E501,W503,E203,D401,R504,R505,SIM102,SIM117
+max-line-length = 120
+max-complexity = 30
+exclude=_*,.vscode,.git,docs/**
+# docstrings
+docstring-convention=google
+# annotations
+suppress-none-returning=True
+allow-star-arg-any=True

--- a/robotic_world_model/.gitattributes
+++ b/robotic_world_model/.gitattributes
@@ -1,0 +1,18 @@
+# copied and modified from https://github.com/NVIDIA/warp/blob/main/.gitattributes
+* text=auto
+*.sh text eol=LF
+
+# copied from https://github.com/isaac-sim/IsaacLab/blob/main/.gitattributes
+*.usd filter=lfs diff=lfs merge=lfs -text
+*.dae filter=lfs diff=lfs merge=lfs -text
+*.mtl filter=lfs diff=lfs merge=lfs -text
+*.obj filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.psd filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.usda filter=lfs diff=lfs merge=lfs -text
+*.hdr filter=lfs diff=lfs merge=lfs -text
+*.pt filter=lfs diff=lfs merge=lfs -text
+*.jit filter=lfs diff=lfs merge=lfs -text

--- a/robotic_world_model/.gitignore
+++ b/robotic_world_model/.gitignore
@@ -1,0 +1,74 @@
+# C++
+**/cmake-build*/
+**/build*/
+**/*.so
+**/*.log*
+
+# Omniverse
+**/*.dmp
+**/.thumbs
+
+# No USDc and USDz files allowed in the repo
+**/*.usdc
+**/*.usdz
+
+# Python
+.DS_Store
+**/*.egg-info/
+**/__pycache__/
+**/.pytest_cache/
+**/*.pyc
+**/*.pb
+
+# Docker/Singularity
+**/*.sif
+docker/cluster/exports/
+docker/.container.cfg
+docker/.env.mbrl
+docker/.env.mbrl-dev
+docker/.mount.config
+docker/docker-compose.override.yaml
+docker/cluster/.env.cluster
+
+# IDE
+**/.idea/
+**/.vscode/
+# Don't ignore the top-level .vscode directory as it is
+# used to configure VS Code settings
+!.vscode
+
+# Outputs
+**/output/*
+**/outputs/*
+**/videos/*
+**/wandb/*
+**/.neptune/*
+docker/artifacts/
+*.tmp
+
+# Doc Outputs
+**/docs/_build/*
+**/generated/*
+
+# Isaac-Sim packman
+_isaac_sim*
+_repo
+_build
+.lastformat
+
+# RL-Games
+**/runs/*
+**/logs/*
+**/recordings/*
+
+# Pre-Trained Checkpoints
+/.pretrained_checkpoints/
+
+# Teleop Recorded Dataset
+datasets
+
+# Tests
+tests/
+
+# Docker history
+.isaac-lab-docker-history

--- a/robotic_world_model/.pre-commit-config.yaml
+++ b/robotic_world_model/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+repos:
+  - repo: https://github.com/python/black
+    rev: 23.10.1
+    hooks:
+      - id: black
+        args: ["--line-length", "120", "--preview"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-simplify, flake8-return]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-toml
+      - id: end-of-file-fixer
+      - id: check-shebang-scripts-are-executable
+      - id: detect-private-key
+      - id: debug-statements
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python)
+        args: ["--profile", "black", "--filter-files"]
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        additional_dependencies:
+        - tomli
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal

--- a/robotic_world_model/.vscode/.gitignore
+++ b/robotic_world_model/.vscode/.gitignore
@@ -1,0 +1,10 @@
+# Note: These files are kept for development purposes only.
+!tools/launch.template.json
+!tools/settings.template.json
+!tools/setup_vscode.py
+!extensions.json
+!tasks.json
+
+# Ignore all other files
+.python.env
+*.json

--- a/robotic_world_model/.vscode/tools/setup_vscode.py
+++ b/robotic_world_model/.vscode/tools/setup_vscode.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2024-2025, The Isaac Lab Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""This script sets up the vs-code settings for the Isaac Lab project.
+
+This script merges the python.analysis.extraPaths from the "{ISAACSIM_DIR}/.vscode/settings.json" file into
+the ".vscode/settings.json" file.
+
+This is necessary because Isaac Sim 2022.2.1 onwards does not add the necessary python packages to the python path
+when the "setup_python_env.sh" is run as part of the vs-code launch configuration.
+"""
+
+import argparse
+import os
+import pathlib
+import platform
+import re
+import sys
+
+PROJECT_DIR = pathlib.Path(__file__).parents[2]
+"""Path to the the project directory."""
+
+try:
+    import isaacsim  # noqa: F401
+
+    isaacsim_dir = os.environ.get("ISAAC_PATH", "")
+except ModuleNotFoundError or ImportError:
+    # Create a parser to get the isaac-sim path
+    parser = argparse.ArgumentParser(description="Setup the VSCode settings for the project.")
+    parser.add_argument("--isaac_path", type=str, help="The absolute path to the Isaac Sim installation.")
+    args = parser.parse_args()
+
+    # parse the isaac-sim directory
+    isaacsim_dir = args.isaac_path
+    # check if the isaac-sim directory is provided
+    if not os.path.exists(isaacsim_dir):
+        raise FileNotFoundError(
+            f"Could not find the isaac-sim directory: {isaacsim_dir}. Please provide the correct path to the Isaac Sim"
+            " installation."
+        )
+except EOFError:
+    print("Unable to trigger EULA acceptance. This is likely due to the script being run in a non-interactive shell.")
+    print("Please run the script in an interactive shell to accept the EULA.")
+    print("Skipping the setup of the VSCode settings...")
+    sys.exit(0)
+
+# check if the isaac-sim directory exists
+if not os.path.exists(isaacsim_dir):
+    raise FileNotFoundError(
+        f"Could not find the isaac-sim directory: {isaacsim_dir}. There are two possible reasons for this:"
+        "\n\t1. The Isaac Sim directory does not exist as provided CLI path."
+        "\n\t2. The script could import the 'isaacsim' package. This could be due to the 'isaacsim' package not being "
+        "installed in the Python environment.\n"
+        "\nPlease make sure that the Isaac Sim directory exists or that the 'isaacsim' package is installed."
+    )
+
+ISAACSIM_DIR = isaacsim_dir
+"""Path to the isaac-sim directory."""
+
+
+def overwrite_python_analysis_extra_paths(isaaclab_settings: str) -> str:
+    """Overwrite the python.analysis.extraPaths in the Isaac Lab settings file.
+
+    The extraPaths are replaced with the path names from the isaac-sim settings file that exists in the
+    "{ISAACSIM_DIR}/.vscode/settings.json" file.
+
+    If the isaac-sim settings file does not exist, the extraPaths are not overwritten.
+
+    Args:
+        isaaclab_settings: The settings string to use as template.
+
+    Returns:
+        The settings string with overwritten python analysis extra paths.
+    """
+    # isaac-sim settings
+    isaacsim_vscode_filename = os.path.join(ISAACSIM_DIR, ".vscode", "settings.json")
+
+    # we use the isaac-sim settings file to get the python.analysis.extraPaths for kit extensions
+    # if this file does not exist, we will not add any extra paths
+    if os.path.exists(isaacsim_vscode_filename):
+        # read the path names from the isaac-sim settings file
+        with open(isaacsim_vscode_filename) as f:
+            vscode_settings = f.read()
+        # extract the path names
+        # search for the python.analysis.extraPaths section and extract the contents
+        settings = re.search(
+            r"\"python.analysis.extraPaths\": \[.*?\]", vscode_settings, flags=re.MULTILINE | re.DOTALL
+        )
+        settings = settings.group(0)
+        settings = settings.split('"python.analysis.extraPaths": [')[-1]
+        settings = settings.split("]")[0]
+
+        # read the path names from the isaac-sim settings file
+        path_names = settings.split(",")
+        path_names = [path_name.strip().strip('"') for path_name in path_names]
+        path_names = [path_name for path_name in path_names if len(path_name) > 0]
+
+        # change the path names to be relative to the Isaac Lab directory
+        rel_path = os.path.relpath(ISAACSIM_DIR, PROJECT_DIR)
+        path_names = ['"${workspaceFolder}/' + rel_path + "/" + path_name + '"' for path_name in path_names]
+    else:
+        path_names = []
+        print(
+            f"[WARN] Could not find Isaac Sim VSCode settings: {isaacsim_vscode_filename}."
+            "\n\tThis will result in missing 'python.analysis.extraPaths' in the VSCode"
+            "\n\tsettings, which limits the functionality of the Python language server."
+            "\n\tHowever, it does not affect the functionality of the Isaac Lab project."
+            "\n\tWe are working on a fix for this issue with the Isaac Sim team."
+        )
+
+    # add the path names that are in the Isaac Lab extensions directory
+    isaaclab_extensions = os.listdir(os.path.join(PROJECT_DIR, "source"))
+    path_names.extend(['"${workspaceFolder}/source/' + ext + '"' for ext in isaaclab_extensions])
+
+    # combine them into a single string
+    path_names = ",\n\t\t".expandtabs(4).join(path_names)
+    # deal with the path separator being different on Windows and Unix
+    path_names = path_names.replace("\\", "/")
+
+    # replace the path names in the Isaac Lab settings file with the path names parsed
+    isaaclab_settings = re.sub(
+        r"\"python.analysis.extraPaths\": \[.*?\]",
+        '"python.analysis.extraPaths": [\n\t\t'.expandtabs(4) + path_names + "\n\t]".expandtabs(4),
+        isaaclab_settings,
+        flags=re.DOTALL,
+    )
+    # return the Isaac Lab settings string
+    return isaaclab_settings
+
+
+def overwrite_default_python_interpreter(isaaclab_settings: str) -> str:
+    """Overwrite the default python interpreter in the Isaac Lab settings file.
+
+    The default python interpreter is replaced with the path to the python interpreter used by the
+    isaac-sim project. This is necessary because the default python interpreter is the one shipped with
+    isaac-sim.
+
+    Args:
+        isaaclab_settings: The settings string to use as template.
+
+    Returns:
+        The settings string with overwritten default python interpreter.
+    """
+    # read executable name
+    python_exe = os.path.normpath(sys.executable)
+
+    # replace with Isaac Sim's python.sh or python.bat scripts to make sure python with correct
+    # source paths is set as default
+    if f"kit{os.sep}python{os.sep}bin{os.sep}python" in python_exe:
+        # Check if the OS is Windows or Linux to use appropriate shell file
+        if platform.system() == "Windows":
+            python_exe = python_exe.replace(f"kit{os.sep}python{os.sep}bin{os.sep}python3", "python.bat")
+        else:
+            python_exe = python_exe.replace(f"kit{os.sep}python{os.sep}bin{os.sep}python3", "python.sh")
+
+    # replace the default python interpreter in the Isaac Lab settings file with the path to the
+    # python interpreter in the Isaac Lab directory
+    isaaclab_settings = re.sub(
+        r"\"python.defaultInterpreterPath\": \".*?\"",
+        f'"python.defaultInterpreterPath": "{python_exe}"',
+        isaaclab_settings,
+        flags=re.DOTALL,
+    )
+    # return the Isaac Lab settings file
+    return isaaclab_settings
+
+
+def main():
+    # Isaac Lab template settings
+    isaaclab_vscode_template_filename = os.path.join(PROJECT_DIR, ".vscode", "tools", "settings.template.json")
+    # make sure the Isaac Lab template settings file exists
+    if not os.path.exists(isaaclab_vscode_template_filename):
+        raise FileNotFoundError(
+            f"Could not find the Isaac Lab template settings file: {isaaclab_vscode_template_filename}"
+        )
+    # read the Isaac Lab template settings file
+    with open(isaaclab_vscode_template_filename) as f:
+        isaaclab_template_settings = f.read()
+
+    # overwrite the python.analysis.extraPaths in the Isaac Lab settings file with the path names
+    isaaclab_settings = overwrite_python_analysis_extra_paths(isaaclab_template_settings)
+    # overwrite the default python interpreter in the Isaac Lab settings file with the path to the
+    # python interpreter used to call this script
+    isaaclab_settings = overwrite_default_python_interpreter(isaaclab_settings)
+
+    # add template notice to the top of the file
+    header_message = (
+        "// This file is a template and is automatically generated by the setup_vscode.py script.\n"
+        "// Do not edit this file directly.\n"
+        "// \n"
+        f"// Generated from: {isaaclab_vscode_template_filename}\n"
+    )
+    isaaclab_settings = header_message + isaaclab_settings
+
+    # write the Isaac Lab settings file
+    isaaclab_vscode_filename = os.path.join(PROJECT_DIR, ".vscode", "settings.json")
+    with open(isaaclab_vscode_filename, "w") as f:
+        f.write(isaaclab_settings)
+
+    # copy the launch.json file if it doesn't exist
+    isaaclab_vscode_launch_filename = os.path.join(PROJECT_DIR, ".vscode", "launch.json")
+    isaaclab_vscode_template_launch_filename = os.path.join(PROJECT_DIR, ".vscode", "tools", "launch.template.json")
+    if not os.path.exists(isaaclab_vscode_launch_filename):
+        # read template launch settings
+        with open(isaaclab_vscode_template_launch_filename) as f:
+            isaaclab_template_launch_settings = f.read()
+        # add header
+        header_message = header_message.replace(
+            isaaclab_vscode_template_filename, isaaclab_vscode_template_launch_filename
+        )
+        isaaclab_launch_settings = header_message + isaaclab_template_launch_settings
+        # write the Isaac Lab launch settings file
+        with open(isaaclab_vscode_launch_filename, "w") as f:
+            f.write(isaaclab_launch_settings)
+
+
+if __name__ == "__main__":
+    main()

--- a/robotic_world_model/LICENCE
+++ b/robotic_world_model/LICENCE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 The Isaac Lab Project Developers
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/robotic_world_model/pyproject.toml
+++ b/robotic_world_model/pyproject.toml
@@ -1,0 +1,85 @@
+[build-system]
+requires = ["setuptools", "toml"]
+build-backend = "setuptools.build_meta"
+
+[tool.isort]
+
+atomic = true
+profile = "black"
+line_length = 120
+py_version = 310
+skip_glob = ["docs/*", "logs/*"]
+group_by_package = true
+
+sections = [
+    "FUTURE",
+    "STDLIB",
+    "THIRDPARTY",
+    "ISAACLABPARTY",
+    "FIRSTPARTY",
+    "LOCALFOLDER",
+]
+extra_standard_library = [
+    "numpy",
+    "h5py",
+    "open3d",
+    "torch",
+    "tensordict",
+    "bpy",
+    "matplotlib",
+    "gymnasium",
+    "gym",
+    "scipy",
+    "hid",
+    "yaml",
+    "prettytable",
+    "toml",
+    "trimesh",
+    "tqdm",
+    "psutil",
+]
+known_thirdparty = [
+    "isaacsim.core.api",
+    "omni.replicator.core",
+    "pxr",
+    "omni.kit.*",
+    "warp",
+    "carb",
+    "Semantics",
+]
+known_isaaclabparty = [
+    "isaaclab",
+    "isaaclab_tasks",
+    "isaaclab_assets",
+    "isaaclab_mimic",
+    "isaaclab_rl"
+]
+
+# Modify the following to include the package names of your first-party code
+known_firstparty = "mbrl"
+known_local_folder = "config"
+
+[tool.pyright]
+
+exclude = [
+    "**/__pycache__",
+    "**/docs",
+    "**/logs",
+    ".git",
+    ".vscode",
+]
+
+typeCheckingMode = "basic"
+pythonVersion = "3.10"
+pythonPlatform = "Linux"
+enableTypeIgnoreComments = true
+
+# This is required as the CI pre-commit does not download the module (i.e. numpy, torch, prettytable)
+# Therefore, we have to ignore missing imports
+reportMissingImports = "none"
+# This is required to ignore for type checks of modules with stubs missing.
+reportMissingModuleSource = "none" # -> most common: prettytable in mdp managers
+
+reportGeneralTypeIssues = "none"       # -> raises 218 errors (usage of literal MISSING in dataclasses)
+reportOptionalMemberAccess = "warning" # -> raises 8 errors
+reportPrivateUsage = "warning"

--- a/robotic_world_model/rwm-u.png
+++ b/robotic_world_model/rwm-u.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c4885b01b3929918d6591717f880d95a11f096f1e11d7708f315e355fff0232
+size 33691402

--- a/robotic_world_model/rwm.png
+++ b/robotic_world_model/rwm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cc43dc37a61b11d5ffc893784835a3dc867eda312fd63ea2996ed1e6001d3df
+size 29511026

--- a/robotic_world_model/scripts/environments/list_envs.py
+++ b/robotic_world_model/scripts/environments/list_envs.py
@@ -1,0 +1,57 @@
+"""
+Script to print all the available environments in the extension.
+
+The script iterates over all registered environments and stores the details in a table.
+It prints the name of the environment, the entry point and the config file.
+"""
+
+"""Launch Isaac Sim Simulator first."""
+
+from isaaclab.app import AppLauncher
+
+# launch omniverse app
+app_launcher = AppLauncher(headless=True)
+simulation_app = app_launcher.app
+
+
+"""Rest everything follows."""
+
+import gymnasium as gym
+from prettytable import PrettyTable
+
+# Import extensions to set up environment tasks
+import mbrl.tasks  # noqa: F401
+
+
+def main():
+    """Print all environments registered in `isaac.lab_demo` extension."""
+    # print all the available environments
+    table = PrettyTable(["S. No.", "Task Name", "Entry Point", "Config"])
+    table.title = "Available Environments in Isaac Lab Template Extension"
+    # set alignment of table columns
+    table.align["Task Name"] = "l"
+    table.align["Entry Point"] = "l"
+    table.align["Config"] = "l"
+
+    # count of environments
+    index = 0
+    # acquire all Isaac environments names
+    for task_spec in gym.registry.values():
+        if "Template-" in task_spec.id:
+            # add details to table
+            table.add_row([index + 1, task_spec.id, task_spec.entry_point, task_spec.kwargs["env_cfg_entry_point"]])
+            # increment count
+            index += 1
+
+    print(table)
+
+
+if __name__ == "__main__":
+    try:
+        # run the main function
+        main()
+    except Exception as e:
+        raise e
+    finally:
+        # close the app
+        simulation_app.close()

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/configs/__init__.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/configs/__init__.py
@@ -1,0 +1,4 @@
+from .base_cfg import BaseConfig
+from .robots import AnymalDFlatConfig, Go2FlatConfig
+
+__all__ = ["BaseConfig", "AnymalDFlatConfig", "Go2FlatConfig"]

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/configs/base_cfg.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/configs/base_cfg.py
@@ -1,0 +1,137 @@
+from dataclasses import dataclass, asdict, field
+from typing import List, Dict
+
+
+@dataclass
+class BaseConfig:
+    experiment_name: str = "online"
+
+    @dataclass
+    class ExperimentConfig:
+        environment: str = "dummy"
+        device: str = "cuda"
+        
+        def to_dict(self):
+            return asdict(self)
+
+    @dataclass
+    class EnvironmentConfig:
+        num_envs: int = 8192
+        max_episode_length: int = 256
+        step_dt: float = 0.02
+        reward_term_weights: Dict[str, float] = field(default_factory=lambda: {"dummy": 0.0})
+        uncertainty_penalty_weight: float = -0.0
+        observation_noise: bool = True
+        command_resample_interval_range: List[int] | None = None
+        event_interval_range: List[int] | None = None
+        
+        def to_dict(self):
+            return asdict(self)
+    
+    @dataclass
+    class DataConfig:       
+        dataset_root: str = "logs/online"
+        dataset_folder: str = "train"
+        file_data_size: int = 10000
+        batch_data_size: int = 50000
+
+        state_idx_dict: Dict[str, List[int]] = field(default_factory=lambda: {"dummy": [0]})
+        state_data_mean: List[float] = field(default_factory=lambda: [0.0])
+        state_data_std: List[float] = field(default_factory=lambda: [0.0])
+        action_data_mean: List[float] = field(default_factory=lambda: [0.0])
+        action_data_std: List[float] = field(default_factory=lambda: [0.0])
+
+        init_data_ratio: float = 0.8
+        num_eval_trajectories: int = 10
+        len_eval_trajectory: int = 400
+        num_visualizations: int = 4
+
+        def to_dict(self):
+            return asdict(self)
+        
+    @dataclass
+    class ModelArchitectureConfig:
+        history_horizon: int = 1 # the window size of the input state transitions
+        forecast_horizon: int = 1 # the autoregressive prediction steps
+        extension_dim: int = 0
+        contact_dim: int = 0
+        termination_dim: int = 0
+        ensemble_size: int = 1
+        architecture_config: Dict[str, object] = field(default_factory=lambda: {
+            "type": "mlp",
+            "base_shape": [256, 256],
+            "state_mean_shape": [128],
+            "state_logstd_shape": [128],
+            "extension_shape": [128],
+            "contact_shape": [128],
+            "termination_shape": [128],
+        })
+        # architecture_config: Dict[str, object] = field(default_factory=lambda: {
+        #     "type": "rnn",
+        #     "rnn_type": "gru",
+        #     "rnn_num_layers": 2,
+        #     "rnn_hidden_size": 256,
+        #     "state_mean_shape": [128],
+        #     "state_logstd_shape": [128],
+        #     "extension_shape": [128],
+        #     "contact_shape": [128],
+        #     "termination_shape": [128],
+        # })
+        freeze_auxiliary: bool = False
+        resume_path: str | None = None
+
+        def to_dict(self):
+            return asdict(self)
+    
+    @dataclass
+    class PolicyArchitectureConfig:
+        observation_dim: int = 0
+        obs_groups: Dict[str, List[str]] = field(default_factory=lambda: {"policy": ["policy"]})
+        action_dim: int = 0
+        actor_hidden_dims: List[int] = field(default_factory=lambda: [128, 128, 128])
+        critic_hidden_dims: List[int] = field(default_factory=lambda: [128, 128, 128])
+        activation: str = "elu"
+        init_noise_std: float = 1.0
+        resume_path: str | None = None
+
+        def to_dict(self):
+            return asdict(self)
+
+    @dataclass
+    class PolicyAlgorithmConfig:
+        value_loss_coef: float = 1.0
+        use_clipped_value_loss: bool = True
+        clip_param: float = 0.2
+        entropy_coef: float = 0.005
+        num_learning_epochs: int = 5
+        num_mini_batches: int = 4
+        learning_rate: float = 1.0e-3
+        schedule: str = "adaptive"
+        gamma: float = 0.99
+        lam: float = 0.95
+        desired_kl: float = 0.01
+        max_grad_norm: float = 1.0
+
+        def to_dict(self):
+            return asdict(self)
+
+    @dataclass
+    class PolicyTrainingConfig:
+        num_steps_per_env: int = 24
+        save_interval: int = 200
+        max_iterations: int = 500
+        export_dir: str | None = None
+        
+        def to_dict(self):
+            return asdict(self)
+
+    def to_dict(self):
+        return asdict(self)
+
+    experiment_config: ExperimentConfig = field(default_factory=ExperimentConfig)
+    environment_config: EnvironmentConfig = field(default_factory=EnvironmentConfig)
+    data_config: DataConfig = field(default_factory=DataConfig)
+    model_architecture_config: ModelArchitectureConfig = field(default_factory=ModelArchitectureConfig)
+    policy_architecture_config: PolicyArchitectureConfig = field(default_factory=PolicyArchitectureConfig)
+    policy_algorithm_config: PolicyAlgorithmConfig = field(default_factory=PolicyAlgorithmConfig)
+    policy_training_config: PolicyTrainingConfig = field(default_factory=PolicyTrainingConfig)

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/configs/robots/__init__.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/configs/robots/__init__.py
@@ -1,0 +1,4 @@
+from .anymal_d_flat_cfg import AnymalDFlatConfig
+from .go2_flat_cfg import Go2FlatConfig
+
+__all__ = ["AnymalDFlatConfig", "Go2FlatConfig"]

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/configs/robots/anymal_d_flat_cfg.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/configs/robots/anymal_d_flat_cfg.py
@@ -1,0 +1,108 @@
+from ..base_cfg import BaseConfig
+from dataclasses import dataclass, asdict, field
+from typing import List, Dict
+
+
+@dataclass
+class AnymalDFlatConfig(BaseConfig):
+    experiment_name: str = "offline"
+
+    @dataclass
+    class ExperimentConfig(BaseConfig.ExperimentConfig):
+        environment: str = "anymal_d_flat"
+
+    @dataclass
+    class EnvironmentConfig(BaseConfig.EnvironmentConfig):
+        reward_term_weights: Dict[str, float] = field(default_factory=lambda: {
+            "track_lin_vel_xy_exp": 1.0,
+            "track_ang_vel_z_exp": 0.5,
+            "lin_vel_z_l2": -2.0,
+            "ang_vel_xy_l2": -0.05,
+            "dof_torques_l2": -2.5e-5,
+            "dof_acc_l2": -2.5e-7,
+            "action_rate_l2": -0.01,
+            "feet_air_time": 0.5,
+            "undesired_contacts": -1.0,
+            "stand_still": -1.0,
+            "flat_orientation_l2": -5.0,
+            "dof_pos_limits": 0.0,
+        })
+        uncertainty_penalty_weight: float = -1.0
+        command_resample_interval_range: List[int] | None = field(default_factory=lambda: [100, 120])
+        event_interval_range: List[int] = field(default_factory=lambda: [48, 96])
+
+    @dataclass
+    class DataConfig(BaseConfig.DataConfig):
+        dataset_root: str = "assets"
+        dataset_folder: str = "data"
+        batch_data_size: int = 10000
+        state_idx_dict: Dict[str, List[int]] = field(default_factory=lambda: {
+            r"$v$\n$[m/s]$": [0, 1, 2],
+            r"$\omega$\n$[rad/s]$": [3, 4, 5],
+            r"$g$\n$[1]$": [6, 7, 8],
+            r"$q$\n$[rad]$": [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+            r"$\dot{q}$\n$[rad/s]$": [21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+            r"$\tau$\n$[Nm]$": [33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44],
+        })
+        state_data_mean: List[float] = field(default_factory=lambda: [
+            0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0,
+            0.0, 0.0, -1.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+            -2.0, -2.0, 2.0, 2.0, -6.0, 8.0, -6.0, 8.0, 12.0, -12.0, 12.0, -12.0,
+        ])
+        state_data_std: List[float] = field(default_factory=lambda: [
+            0.5, 0.5, 0.1,
+            0.3, 0.3, 0.5,
+            0.02, 0.02, 0.04,
+            0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15,
+            1.0, 1.0, 1.0, 1.0, 1.5, 1.5, 1.5, 1.5, 2.5, 2.5, 2.5, 2.5,
+            15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0,
+        ])
+        action_data_mean: List[float] = field(default_factory=lambda: [0.0] * 12)
+        action_data_std: List[float] = field(default_factory=lambda: [1.0] * 12)
+
+    @dataclass
+    class ModelArchitectureConfig(BaseConfig.ModelArchitectureConfig):
+        history_horizon: int = 32
+        forecast_horizon: int = 8
+        ensemble_size: int = 5
+        contact_dim: int = 8
+        termination_dim: int = 1
+        architecture_config: Dict[str, object] = field(default_factory=lambda: {
+            "type": "rnn",
+            "rnn_type": "gru",
+            "rnn_num_layers": 2,
+            "rnn_hidden_size": 256,
+            "state_mean_shape": [128],
+            "state_logstd_shape": [128],
+            "extension_shape": [128],
+            "contact_shape": [128],
+            "termination_shape": [128],
+        })
+        resume_path: str | None = "assets/models/pretrain_rnn_ens.pt"
+
+    @dataclass
+    class PolicyArchitectureConfig(BaseConfig.PolicyArchitectureConfig):
+        observation_dim: int = 48
+        action_dim: int = 12
+        resume_path: str | None = None
+
+    @dataclass
+    class PolicyAlgorithmConfig(BaseConfig.PolicyAlgorithmConfig):
+        learning_rate: float = 1.0e-4
+        entropy_coef: float = 0.0001
+
+    @dataclass
+    class PolicyTrainingConfig(BaseConfig.PolicyTrainingConfig):
+        save_interval: int = 50
+        max_iterations: int = 500
+
+    experiment_config: ExperimentConfig = field(default_factory=ExperimentConfig)
+    environment_config: EnvironmentConfig = field(default_factory=EnvironmentConfig)
+    data_config: DataConfig = field(default_factory=DataConfig)
+    model_architecture_config: ModelArchitectureConfig = field(default_factory=ModelArchitectureConfig)
+    policy_architecture_config: PolicyArchitectureConfig = field(default_factory=PolicyArchitectureConfig)
+    policy_algorithm_config: PolicyAlgorithmConfig = field(default_factory=PolicyAlgorithmConfig)
+    policy_training_config: PolicyTrainingConfig = field(default_factory=PolicyTrainingConfig)

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/configs/robots/go2_flat_cfg.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/configs/robots/go2_flat_cfg.py
@@ -1,0 +1,99 @@
+from ..base_cfg import BaseConfig
+from dataclasses import dataclass, asdict, field
+from typing import List, Dict
+
+
+@dataclass
+class Go2FlatConfig(BaseConfig):
+    experiment_name: str = "offline"
+
+    @dataclass
+    class ExperimentConfig(BaseConfig.ExperimentConfig):
+        environment: str = "go2_flat"
+
+    @dataclass
+    class EnvironmentConfig(BaseConfig.EnvironmentConfig):
+        reward_term_weights: Dict[str, float] = field(default_factory=lambda: {
+            "track_lin_vel_xy_exp": 1.5,
+            "track_ang_vel_z_exp": 0.75,
+            "lin_vel_z_l2": -2.5,
+            "ang_vel_xy_l2": -0.1,
+            "dof_torques_l2": -2.5e-5,
+            "dof_acc_l2": -2.5e-7,
+            "action_rate_l2": -0.01,
+            "feet_air_time": 0.35,
+            "undesired_contacts": 0.0,
+            "joint_pos_posture": -0.06,
+            "stand_still": -1.0,
+            "flat_orientation_l2": -6.0,
+            "dof_pos_limits": 0.0,
+        })
+        uncertainty_penalty_weight: float = -1.0
+        command_resample_interval_range: List[int] | None = field(default_factory=lambda: [100, 120])
+        event_interval_range: List[int] = field(default_factory=lambda: [48, 96])
+
+    @dataclass
+    class DataConfig(BaseConfig.DataConfig):
+        dataset_root: str = "assets"
+        dataset_folder: str = "data"
+        batch_data_size: int = 10000
+        state_idx_dict: Dict[str, List[int]] = field(default_factory=lambda: {
+            r"$v$\n$[m/s]$": [0, 1, 2],
+            r"$\omega$\n$[rad/s]$": [3, 4, 5],
+            r"$g$\n$[1]$": [6, 7, 8],
+            r"$q$\n$[rad]$": [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+            r"$\dot{q}$\n$[rad/s]$": [21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+            r"$\tau$\n$[Nm]$": [33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44],
+        })
+        state_data_mean: List[float] = field(default_factory=lambda: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0] + [0.0] * 36)
+        state_data_std: List[float] = field(default_factory=lambda: [
+            0.5, 0.5, 0.1,
+            0.3, 0.3, 0.5,
+            0.02, 0.02, 0.04,
+        ] + [0.2] * 12 + [2.0] * 12 + [8.0] * 12)
+        action_data_mean: List[float] = field(default_factory=lambda: [0.0] * 12)
+        action_data_std: List[float] = field(default_factory=lambda: [1.0] * 12)
+
+    @dataclass
+    class ModelArchitectureConfig(BaseConfig.ModelArchitectureConfig):
+        history_horizon: int = 32
+        forecast_horizon: int = 8
+        ensemble_size: int = 5
+        contact_dim: int = 8
+        termination_dim: int = 1
+        architecture_config: Dict[str, object] = field(default_factory=lambda: {
+            "type": "rnn",
+            "rnn_type": "gru",
+            "rnn_num_layers": 2,
+            "rnn_hidden_size": 256,
+            "state_mean_shape": [128],
+            "state_logstd_shape": [128],
+            "extension_shape": [128],
+            "contact_shape": [128],
+            "termination_shape": [128],
+        })
+        resume_path: str | None = "assets/models/pretrain_rnn_ens.pt"
+
+    @dataclass
+    class PolicyArchitectureConfig(BaseConfig.PolicyArchitectureConfig):
+        observation_dim: int = 48
+        action_dim: int = 12
+        resume_path: str | None = None
+
+    @dataclass
+    class PolicyAlgorithmConfig(BaseConfig.PolicyAlgorithmConfig):
+        learning_rate: float = 1.0e-4
+        entropy_coef: float = 0.0005
+
+    @dataclass
+    class PolicyTrainingConfig(BaseConfig.PolicyTrainingConfig):
+        save_interval: int = 50
+        max_iterations: int = 500
+
+    experiment_config: ExperimentConfig = field(default_factory=ExperimentConfig)
+    environment_config: EnvironmentConfig = field(default_factory=EnvironmentConfig)
+    data_config: DataConfig = field(default_factory=DataConfig)
+    model_architecture_config: ModelArchitectureConfig = field(default_factory=ModelArchitectureConfig)
+    policy_architecture_config: PolicyArchitectureConfig = field(default_factory=PolicyArchitectureConfig)
+    policy_algorithm_config: PolicyAlgorithmConfig = field(default_factory=PolicyAlgorithmConfig)
+    policy_training_config: PolicyTrainingConfig = field(default_factory=PolicyTrainingConfig)

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/envs/__init__.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/envs/__init__.py
@@ -1,0 +1,4 @@
+from .base import BaseEnv
+from .robots import AnymalDFlatEnv, Go2FlatEnv
+
+__all__ = ["BaseEnv", "AnymalDFlatEnv", "Go2FlatEnv"]

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/envs/base.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/envs/base.py
@@ -1,0 +1,246 @@
+import torch
+from tensordict import TensorDict
+
+
+class BaseEnv:
+    def __init__(
+        self,
+        num_envs: int,
+        max_episode_length: int,
+        step_dt: float,
+        reward_term_weights: dict,
+        device: str,
+        uncertainty_penalty_weight:float = -0.0,
+        observation_noise: bool = False,
+        command_resample_interval_range: list | None = [500, 500],
+        event_interval_range: list | None = None,
+        ):
+        self._num_envs = num_envs
+        self._max_episode_length = max_episode_length
+        self._step_dt = step_dt
+        self.device = device
+
+        self.reward_term_weights = reward_term_weights
+        self.uncertainty_penalty_weight = uncertainty_penalty_weight
+        self.observation_noise = observation_noise
+        self.command_resample_interval_range = command_resample_interval_range
+        self.event_interval_range = event_interval_range
+        self._init_additional_attributes()
+        self.dummy_obs = TensorDict({"policy": torch.zeros(num_envs, self.observation_dim)}, batch_size=[num_envs], device=self.device)
+
+        # set in experiment
+        self.system_dynamics = None
+        self.dataset = None
+        self.init_dataset = None
+        self.init_data_ratio = None
+
+    def _init_additional_attributes(self):
+        pass
+    
+    def set_system_dynamics(self, system_dynamics):
+        self.system_dynamics = system_dynamics
+        self.system_dynamics.eval()
+        
+    def set_dataset(self, dataset):
+        self.dataset = dataset
+        
+    def set_init_dataset(self, init_dataset, init_data_ratio=0.0):
+        self.init_dataset = init_dataset
+        self.init_data_ratio = init_data_ratio
+
+    def prepare_imagination(self):
+        self.common_step_counter = 0
+        self.system_dynamics.reset()
+        self.system_dynamics_model_ids = torch.randint(0, self.system_dynamics.ensemble_size, (1, self._num_envs, 1), device=self.device)
+        self._init_imagination_reward_buffer()
+        self._init_intervals()
+        self._init_additional_imagination_attributes()
+        state_history, action_history = self._init_imagination_history()
+        self._init_imagination_command()
+        self.last_obs = TensorDict({"policy": torch.zeros(self._num_envs, self.observation_dim)}, batch_size=[self._num_envs], device=self.device)
+        self.extras = {}
+        self._reset_idx(torch.arange(self._num_envs, device=self.device))
+        return state_history, action_history
+    
+    def _reset_idx(self, env_ids):
+        self.extras["log"] = dict()
+        self.system_dynamics.reset_partial(env_ids)
+        self.system_dynamics_model_ids[:, env_ids, :] = torch.randint(0, self.system_dynamics.ensemble_size, (1, len(env_ids), 1), device=self.device)
+        info = self._reset_imagination_reward_buffer(env_ids)
+        self.extras["log"].update(info)
+        self._reset_intervals(env_ids)
+        self._reset_additional_imagination_attributes(env_ids)
+        self.last_obs["policy"][env_ids] = 0.0
+
+    def _init_imagination_history(self):
+        num_init_envs = int(self._num_envs * self.init_data_ratio)
+        num_random_envs = self._num_envs - num_init_envs
+        state_history_init, action_history_init = self.init_dataset.sample_batch(num_init_envs, normalized=True)
+        state_history_random, action_history_random = self.dataset.sample_batch(num_random_envs, normalized=True)
+        state_history = torch.cat([state_history_init, state_history_random], dim=0)
+        action_history = torch.cat([action_history_init, action_history_random], dim=0)
+        return state_history, action_history
+
+    def _reset_imagination_history(self, env_ids, state_history, action_history):
+        num_reset_envs = len(env_ids)
+        num_init_envs = int(num_reset_envs * self.init_data_ratio)
+        num_random_envs = num_reset_envs - num_init_envs
+        state_history_init, action_history_init = self.init_dataset.sample_batch(num_init_envs, normalized=True)
+        state_history_random, action_history_random = self.dataset.sample_batch(num_random_envs, normalized=True)
+        state_history[env_ids] = torch.cat([state_history_init, state_history_random], dim=0)[:, -state_history.shape[1]:]
+        action_history[env_ids] = torch.cat([action_history_init, action_history_random], dim=0)[:, -action_history.shape[1]:]
+        return state_history, action_history
+
+    def _init_imagination_reward_buffer(self):
+        self.episode_length_buf = torch.zeros(self._num_envs, device=self.device, dtype=torch.long)
+        self.imagination_episode_sums = {
+            term: torch.zeros(
+                self._num_envs,
+                device=self.device
+                ) for term in self.reward_term_weights.keys()
+            }
+        self.imagination_episode_sums["uncertainty"] = torch.zeros(self._num_envs, device=self.device)
+        self.imagination_reward_per_step = {
+            term: torch.zeros(
+                self._num_envs,
+                device=self.device
+                ) for term in self.reward_term_weights.keys()
+            }
+    
+    def _reset_imagination_reward_buffer(self, env_ids):
+        extras = {}
+        self.episode_length_buf[env_ids] = 0
+        for term in self.imagination_episode_sums.keys():
+            episodic_sum_avg = torch.mean(self.imagination_episode_sums[term][env_ids])
+            extras[term] = episodic_sum_avg / (self._max_episode_length * self._step_dt)
+            self.imagination_episode_sums[term][env_ids] = 0.0
+        return extras
+
+    def _init_intervals(self):
+        if self.command_resample_interval_range is None:
+            return
+        else:
+            self.command_resample_intervals = torch.randint(self.command_resample_interval_range[0], self.command_resample_interval_range[1], (self._num_envs,), device=self.device)
+        if self.event_interval_range is None:
+            return
+        else:
+            self.event_intervals = torch.randint(self.event_interval_range[0], self.event_interval_range[1], (self._num_envs,), device=self.device)
+
+    def _reset_intervals(self, env_ids):
+        if self.command_resample_interval_range is None:
+            return
+        else:
+            self.command_resample_intervals[env_ids] = torch.randint(self.command_resample_interval_range[0], self.command_resample_interval_range[1], (len(env_ids),), device=self.device)
+        if self.event_interval_range is None:
+            return
+        else:
+            self.event_intervals[env_ids] = torch.randint(self.event_interval_range[0], self.event_interval_range[1], (len(env_ids),), device=self.device)
+
+    def imagination_step(self, rollout_action, state_history, action_history):
+        _, rollout_action_normalized = self.dataset.normalize(None, rollout_action)
+        action_history = torch.cat([action_history[:, 1:], rollout_action_normalized.unsqueeze(1)], dim=1)
+        imagination_states, aleatoric_uncertainty, self.epistemic_uncertainty, extensions, contacts, terminations = self.system_dynamics.forward(state_history, action_history, self.system_dynamics_model_ids)
+        imagination_states_denormalized, _ = self.dataset.denormalize(imagination_states, None)
+        parsed_imagination_states = self._parse_imagination_states(imagination_states_denormalized)
+        parsed_extensions = self._parse_extensions(extensions)
+        parsed_contacts = self._parse_contacts(contacts)
+        self.termination_flags = self._parse_terminations(terminations)
+        self._compute_imagination_reward_terms(parsed_imagination_states, rollout_action, parsed_extensions, parsed_contacts)
+        rewards, dones, extras = self._post_imagination_step()
+        command_ids = self._process_command_env_ids()
+        self._reset_imagination_command(command_ids)
+        event_ids = self._process_event_env_ids()
+        imagination_states = self._apply_interval_events(imagination_states_denormalized, parsed_imagination_states, event_ids)
+        state_history = torch.cat([state_history[:, 1:], imagination_states.unsqueeze(1)], dim=1)
+        reset_env_ids = dones.nonzero(as_tuple=False).squeeze(-1)
+        if len(reset_env_ids) > 0:
+            state_history, action_history = self._reset_imagination_history(reset_env_ids, state_history, action_history)
+        return self.last_obs, rewards, dones, extras, state_history, action_history, self.epistemic_uncertainty
+
+    def _post_imagination_step(self):
+        self.episode_length_buf += 1
+        self.common_step_counter += 1
+        rewards = torch.zeros(self._num_envs, dtype=torch.float, device=self.device)
+        for term in self.imagination_episode_sums.keys():
+            if term == "uncertainty":
+                rewards += self.uncertainty_penalty_weight * self.epistemic_uncertainty * self._step_dt
+                self.imagination_episode_sums[term] += self.uncertainty_penalty_weight * self.epistemic_uncertainty * self._step_dt
+            else:
+                term_value = self.imagination_reward_per_step[term]
+                rewards += self.reward_term_weights[term] * term_value * self._step_dt
+                self.imagination_episode_sums[term] += self.reward_term_weights[term] * term_value * self._step_dt
+        
+        terminated = self.termination_flags if self.termination_flags is not None else torch.zeros(self._num_envs, dtype=torch.bool, device=self.device)
+        time_outs = self.episode_length_buf >= self._max_episode_length
+        dones = (terminated | time_outs).to(dtype=torch.long)
+        
+        reset_env_ids = (terminated | time_outs).nonzero(as_tuple=False).squeeze(-1)
+        if len(reset_env_ids) > 0:
+            self._reset_idx(reset_env_ids)
+        self.extras["time_outs"] = time_outs
+        return rewards, dones, self.extras
+    
+    def _process_command_env_ids(self):
+        if self.command_resample_interval_range is None:
+            return torch.empty(0, dtype=torch.int, device=self.device)
+        else:
+            return (self.episode_length_buf % self.command_resample_intervals == 0).nonzero(as_tuple=False).squeeze(-1)
+
+    def _process_event_env_ids(self):
+        if self.event_interval_range is None:
+            return torch.empty(0, dtype=torch.int, device=self.device)
+        else:
+            return (self.episode_length_buf % self.event_intervals == 0).nonzero(as_tuple=False).squeeze(-1)
+        
+    @property
+    def num_envs(self):
+        return self._num_envs
+    
+    @property
+    def max_episode_length(self):
+        return self._max_episode_length
+
+    def _init_additional_imagination_attributes(self):
+        raise NotImplementedError
+
+    def _reset_additional_imagination_attributes(self, env_ids):
+        raise NotImplementedError
+
+    def _init_imagination_command(self):
+        raise NotImplementedError
+
+    def _reset_imagination_command(self, env_ids):
+        raise NotImplementedError
+
+    def get_imagination_observation(self, state_history, action_history):
+        raise NotImplementedError
+
+    def _parse_imagination_states(self, imagination_states_denormalized):
+        raise NotImplementedError
+
+    def _parse_extensions(self, extensions):
+        raise NotImplementedError
+
+    def _parse_contacts(self, contacts):
+        raise NotImplementedError
+    
+    def _parse_terminations(self, terminations):
+        raise NotImplementedError
+
+    def _compute_imagination_reward_terms(self, parsed_imagination_states, rollout_action, parsed_extensions, parsed_contacts):
+        raise NotImplementedError
+
+    def _apply_interval_events(self, imagination_states_denormalized, parsed_imagination_states, event_ids):
+        raise NotImplementedError
+
+    @property
+    def state_dim(self):
+        raise NotImplementedError
+    
+    @property
+    def observation_dim(self):
+        raise NotImplementedError
+    
+    @property
+    def action_dim(self):
+        raise NotImplementedError

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/envs/robots/__init__.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/envs/robots/__init__.py
@@ -1,0 +1,4 @@
+from .anymal_d_flat import AnymalDFlatEnv
+from .go2_flat import Go2FlatEnv
+
+__all__ = ["AnymalDFlatEnv", "Go2FlatEnv"]

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/envs/robots/anymal_d_flat.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/envs/robots/anymal_d_flat.py
@@ -1,0 +1,186 @@
+from ..base import BaseEnv
+import torch
+from tensordict import TensorDict
+
+
+class AnymalDFlatEnv(BaseEnv):
+    def _init_additional_imagination_attributes(self):
+        self.last_air_time = torch.zeros(self.num_envs, 4, device=self.device)
+        self.current_air_time = torch.zeros(self.num_envs, 4, device=self.device)
+        self.last_contact_time = torch.zeros(self.num_envs, 4, device=self.device)
+        self.current_contact_time = torch.zeros(self.num_envs, 4, device=self.device)
+
+    def _reset_additional_imagination_attributes(self, env_ids):
+        self.last_air_time[env_ids] = 0.0
+        self.current_air_time[env_ids] = 0.0
+        self.last_contact_time[env_ids] = 0.0
+        self.current_contact_time[env_ids] = 0.0
+
+    def _init_imagination_command(self):
+        r = torch.empty(self.num_envs, device=self.device)
+        self.base_velocity = torch.zeros(self.num_envs, 3, device=self.device)
+        self.is_standing_env = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
+        self.base_velocity[:, 0] = r.uniform_(-1.0, 1.0)
+        self.base_velocity[:, 1] = r.uniform_(-1.0, 1.0)
+        self.base_velocity[:, 2] = r.uniform_(-1.0, 1.0)
+        self.is_standing_env[:] = r.uniform_(0.0, 1.0) <= 0.02
+        standing_env_ids = self.is_standing_env.nonzero(as_tuple=False).flatten()
+        self.base_velocity[standing_env_ids, :] = 0.0
+
+    def _reset_imagination_command(self, env_ids):
+        r = torch.empty(len(env_ids), device=self.device)
+        self.base_velocity[env_ids, 0] = r.uniform_(-1.0, 1.0)
+        self.base_velocity[env_ids, 1] = r.uniform_(-1.0, 1.0)
+        self.base_velocity[env_ids, 2] = r.uniform_(-1.0, 1.0)
+        self.is_standing_env[env_ids] = r.uniform_(0.0, 1.0) <= 0.02
+        standing_env_ids = self.is_standing_env.nonzero(as_tuple=False).flatten()
+        self.base_velocity[standing_env_ids, :] = 0.0
+
+    def get_imagination_observation(self, state_history, action_history):
+        state_history_denormalized, action_history_denormalized = self.dataset.denormalize(state_history[:, -1], action_history[:, -1])
+        obs_base_lin_vel = state_history_denormalized[:, 0:3]
+        obs_base_ang_vel = state_history_denormalized[:, 3:6]
+        obs_projected_gravity = state_history_denormalized[:, 6:9]
+        obs_joint_pos = state_history_denormalized[:, 9:21]
+        obs_joint_vel = state_history_denormalized[:, 21:33]
+        self.obs_last_action = action_history_denormalized
+        if self.observation_noise:
+            obs_base_lin_vel += 2 * (torch.rand_like(obs_base_lin_vel) - 0.5) * 0.1
+            obs_base_ang_vel += 2 * (torch.rand_like(obs_base_ang_vel) - 0.5) * 0.2
+            obs_projected_gravity += 2 * (torch.rand_like(obs_projected_gravity) - 0.5) * 0.05
+            obs_joint_pos += 2 * (torch.rand_like(obs_joint_pos) - 0.5) * 0.01
+            obs_joint_vel += 2 * (torch.rand_like(obs_joint_vel) - 0.5) * 1.5
+        obs = torch.cat([obs_base_lin_vel, obs_base_ang_vel, obs_projected_gravity, self.base_velocity, obs_joint_pos, obs_joint_vel, self.obs_last_action], dim=1)
+        obs = TensorDict({"policy": obs}, batch_size=[self.num_envs], device=self.device)
+        self.last_obs = obs
+        return obs
+
+    def _parse_imagination_states(self, imagination_states_denormalized):
+        base_lin_vel = imagination_states_denormalized[:, 0:3]
+        base_ang_vel = imagination_states_denormalized[:, 3:6]
+        projected_gravity = imagination_states_denormalized[:, 6:9]
+        joint_pos = imagination_states_denormalized[:, 9:21]
+        joint_vel = imagination_states_denormalized[:, 21:33]
+        joint_torque = imagination_states_denormalized[:, 33:45]
+
+        parsed_imagination_states = {
+            "base_lin_vel": base_lin_vel,
+            "base_ang_vel": base_ang_vel,
+            "projected_gravity": projected_gravity,
+            "joint_pos": joint_pos,
+            "joint_vel": joint_vel,
+            "joint_torque": joint_torque,
+        }
+        return parsed_imagination_states
+
+    def _parse_extensions(self, extensions):
+        if extensions is None:
+            return None
+        parsed_extensions = {}
+        return parsed_extensions
+
+    def _parse_contacts(self, contacts):
+        thigh_contact = torch.sigmoid(contacts[:, 0:4]).round() if contacts is not None else None
+        foot_contact = torch.sigmoid(contacts[:, 4:8]).round() if contacts is not None else None
+
+        parsed_contacts = {
+            "thigh_contact": thigh_contact,
+            "foot_contact": foot_contact,
+        }
+        return parsed_contacts
+
+    def _parse_terminations(self, terminations):
+        parsed_terminations = torch.sigmoid(terminations).squeeze(-1).round().bool() if terminations is not None else None
+        return parsed_terminations
+
+    def _compute_imagination_reward_terms(self, parsed_imagination_states, rollout_action, parsed_extensions, parsed_contacts):
+        base_lin_vel = parsed_imagination_states["base_lin_vel"]
+        base_ang_vel = parsed_imagination_states["base_ang_vel"]
+        projected_gravity = parsed_imagination_states["projected_gravity"]
+        joint_pos = parsed_imagination_states["joint_pos"]
+        joint_vel = parsed_imagination_states["joint_vel"]
+        joint_torque = parsed_imagination_states["joint_torque"]
+        joint_acc = (joint_vel - self.last_obs["policy"][:, 12:24]) / self._step_dt
+        thigh_contact = parsed_contacts["thigh_contact"]
+        foot_contact = parsed_contacts["foot_contact"]
+
+        lin_vel_error = torch.sum(torch.square(self.base_velocity[:, :2] - base_lin_vel[:, :2]), dim=1)
+        ang_vel_error = torch.square(self.base_velocity[:, 2] - base_ang_vel[:, 2])
+
+        track_lin_vel_xy_exp = torch.exp(-lin_vel_error / 0.25)
+        track_ang_vel_z_exp = torch.exp(-ang_vel_error / 0.25)
+        lin_vel_z_l2 = torch.square(base_lin_vel[:, 2])
+        ang_vel_xy_l2 = torch.sum(torch.square(base_ang_vel[:, :2]), dim=1)
+        dof_torques_l2 = torch.sum(torch.square(joint_torque), dim=1)
+        dof_acc_l2 = torch.sum(torch.square(joint_acc), dim=1)
+        action_rate_l2 = torch.sum(torch.square(self.obs_last_action - rollout_action), dim=1)
+        if foot_contact is not None:
+            first_contact = (self.current_contact_time > 0.0) * (self.current_contact_time < (self._step_dt + 1.0e-8))
+            feet_air_time = torch.sum((self.last_air_time - 0.5) * first_contact, dim=1) * (torch.norm(self.base_velocity[:, :2], dim=1) > 0.1)
+
+            is_contact = foot_contact.bool()
+            is_first_contact = (self.current_air_time > 0) * is_contact
+            is_first_detached = (self.current_contact_time > 0) * ~is_contact
+            self.last_air_time = torch.where(
+                is_first_contact,
+                self.current_air_time + self._step_dt,
+                self.last_air_time,
+            )
+            self.current_air_time = torch.where(
+                ~is_contact, self.current_air_time + self._step_dt, 0.0
+            )
+            self.last_contact_time = torch.where(
+                is_first_detached,
+                self.current_contact_time + self._step_dt,
+                self.last_contact_time,
+            )
+            self.current_contact_time = torch.where(
+                is_contact, self.current_contact_time + self._step_dt, 0.0
+            )
+        else:
+            feet_air_time = torch.zeros(self.num_envs, device=self.device)
+        undesired_contacts = torch.sum(thigh_contact, dim=1) if thigh_contact is not None else torch.zeros(self.num_envs, device=self.device)
+        stand_still = torch.sum(torch.abs(joint_pos), dim=1) * (torch.norm(self.base_velocity, dim=1) < 0.05)
+        flat_orientation_l2 = torch.sum(torch.square(projected_gravity[:, :2]), dim=1)
+        dof_pos_limits = torch.zeros(self.num_envs, device=self.device)
+        self.imagination_reward_per_step = {
+            "track_lin_vel_xy_exp": track_lin_vel_xy_exp,
+            "track_ang_vel_z_exp": track_ang_vel_z_exp,
+            "lin_vel_z_l2": lin_vel_z_l2,
+            "ang_vel_xy_l2": ang_vel_xy_l2,
+            "dof_torques_l2": dof_torques_l2,
+            "dof_acc_l2": dof_acc_l2,
+            "action_rate_l2": action_rate_l2,
+            "feet_air_time": feet_air_time,
+            "undesired_contacts": undesired_contacts,
+            "stand_still": stand_still,
+            "flat_orientation_l2": flat_orientation_l2,
+            "dof_pos_limits": dof_pos_limits,
+        }
+        last_obs = torch.cat([base_lin_vel, base_ang_vel, projected_gravity, self.base_velocity, joint_pos, joint_vel, rollout_action], dim=1)
+        self.last_obs = TensorDict({"policy": last_obs}, batch_size=[self.num_envs], device=self.device)
+
+    def _apply_interval_events(self, imagination_states_denormalized, parsed_imagination_states, event_ids):
+        if len(event_ids) == 0:
+            imagination_states, _ = self.dataset.normalize(imagination_states_denormalized, None)
+        else:
+            base_lin_vel = parsed_imagination_states["base_lin_vel"]
+            velocity_range = {"x": (-0.5, 0.5), "y": (-0.5, 0.5)}
+            r = torch.empty(len(event_ids), device=self.device)
+            base_lin_vel[event_ids, 0] += r.uniform_(*velocity_range["x"])
+            base_lin_vel[event_ids, 1] += r.uniform_(*velocity_range["y"])
+            imagination_states_denormalized[event_ids, 0:3] = base_lin_vel[event_ids, 0:3]
+            imagination_states, _ = self.dataset.normalize(imagination_states_denormalized, None)
+        return imagination_states
+
+    @property
+    def state_dim(self):
+        return 45
+
+    @property
+    def observation_dim(self):
+        return 48
+
+    @property
+    def action_dim(self):
+        return 12

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/envs/robots/go2_flat.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/envs/robots/go2_flat.py
@@ -1,0 +1,197 @@
+from ..base import BaseEnv
+import torch
+from tensordict import TensorDict
+
+
+class Go2FlatEnv(BaseEnv):
+    def _init_additional_imagination_attributes(self):
+        self.last_air_time = torch.zeros(self.num_envs, 4, device=self.device)
+        self.current_air_time = torch.zeros(self.num_envs, 4, device=self.device)
+        self.last_contact_time = torch.zeros(self.num_envs, 4, device=self.device)
+        self.current_contact_time = torch.zeros(self.num_envs, 4, device=self.device)
+
+    def _reset_additional_imagination_attributes(self, env_ids):
+        self.last_air_time[env_ids] = 0.0
+        self.current_air_time[env_ids] = 0.0
+        self.last_contact_time[env_ids] = 0.0
+        self.current_contact_time[env_ids] = 0.0
+
+    def _init_imagination_command(self):
+        r = torch.empty(self.num_envs, device=self.device)
+        self.base_velocity = torch.zeros(self.num_envs, 3, device=self.device)
+        self.is_standing_env = torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
+        self.base_velocity[:, 0] = r.uniform_(-1.0, 1.0)
+        self.base_velocity[:, 1] = r.uniform_(-1.0, 1.0)
+        self.base_velocity[:, 2] = r.uniform_(-1.0, 1.0)
+        self.is_standing_env[:] = r.uniform_(0.0, 1.0) <= 0.02
+        standing_env_ids = self.is_standing_env.nonzero(as_tuple=False).flatten()
+        self.base_velocity[standing_env_ids, :] = 0.0
+
+    def _reset_imagination_command(self, env_ids):
+        r = torch.empty(len(env_ids), device=self.device)
+        self.base_velocity[env_ids, 0] = r.uniform_(-1.0, 1.0)
+        self.base_velocity[env_ids, 1] = r.uniform_(-1.0, 1.0)
+        self.base_velocity[env_ids, 2] = r.uniform_(-1.0, 1.0)
+        self.is_standing_env[env_ids] = r.uniform_(0.0, 1.0) <= 0.02
+        standing_env_ids = self.is_standing_env.nonzero(as_tuple=False).flatten()
+        self.base_velocity[standing_env_ids, :] = 0.0
+
+    def get_imagination_observation(self, state_history, action_history):
+        state_history_denormalized, action_history_denormalized = self.dataset.denormalize(state_history[:, -1], action_history[:, -1])
+        obs_base_lin_vel = state_history_denormalized[:, 0:3]
+        obs_base_ang_vel = state_history_denormalized[:, 3:6]
+        obs_projected_gravity = state_history_denormalized[:, 6:9]
+        obs_joint_pos = state_history_denormalized[:, 9:21]
+        obs_joint_vel = state_history_denormalized[:, 21:33]
+        self.obs_last_action = action_history_denormalized
+        if self.observation_noise:
+            obs_base_lin_vel += 2 * (torch.rand_like(obs_base_lin_vel) - 0.5) * 0.1
+            obs_base_ang_vel += 2 * (torch.rand_like(obs_base_ang_vel) - 0.5) * 0.2
+            obs_projected_gravity += 2 * (torch.rand_like(obs_projected_gravity) - 0.5) * 0.05
+            obs_joint_pos += 2 * (torch.rand_like(obs_joint_pos) - 0.5) * 0.01
+            obs_joint_vel += 2 * (torch.rand_like(obs_joint_vel) - 0.5) * 1.5
+        obs = torch.cat([obs_base_lin_vel, obs_base_ang_vel, obs_projected_gravity, self.base_velocity, obs_joint_pos, obs_joint_vel, self.obs_last_action], dim=1)
+        obs = TensorDict({"policy": obs}, batch_size=[self.num_envs], device=self.device)
+        self.last_obs = obs
+        return obs
+
+    def _parse_imagination_states(self, imagination_states_denormalized):
+        base_lin_vel = imagination_states_denormalized[:, 0:3]
+        base_ang_vel = imagination_states_denormalized[:, 3:6]
+        projected_gravity = imagination_states_denormalized[:, 6:9]
+        joint_pos = imagination_states_denormalized[:, 9:21]
+        joint_vel = imagination_states_denormalized[:, 21:33]
+        joint_torque = imagination_states_denormalized[:, 33:45]
+
+        # Clamp dynamic model outputs to avoid out-of-distribution states during rollout
+        base_lin_vel[:, :2] = torch.clamp(base_lin_vel[:, :2], -3.0, 3.0)
+        base_lin_vel[:, 2] = torch.clamp(base_lin_vel[:, 2], -1.5, 1.5)
+        base_ang_vel = torch.clamp(base_ang_vel, -6.0, 6.0)
+        projected_gravity = torch.nn.functional.normalize(projected_gravity, dim=1, eps=1.0e-6)
+        joint_pos = torch.clamp(joint_pos, -1.2, 1.2)
+        joint_vel = torch.clamp(joint_vel, -30.0, 30.0)
+        joint_torque = torch.clamp(joint_torque, -80.0, 80.0)
+
+        parsed_imagination_states = {
+            "base_lin_vel": base_lin_vel,
+            "base_ang_vel": base_ang_vel,
+            "projected_gravity": projected_gravity,
+            "joint_pos": joint_pos,
+            "joint_vel": joint_vel,
+            "joint_torque": joint_torque,
+        }
+        return parsed_imagination_states
+
+    def _parse_extensions(self, extensions):
+        if extensions is None:
+            return None
+        parsed_extensions = {}
+        return parsed_extensions
+
+    def _parse_contacts(self, contacts):
+        thigh_contact = torch.sigmoid(contacts[:, 0:4]).round() if contacts is not None else None
+        foot_contact = torch.sigmoid(contacts[:, 4:8]).round() if contacts is not None else None
+
+        parsed_contacts = {
+            "thigh_contact": thigh_contact,
+            "foot_contact": foot_contact,
+        }
+        return parsed_contacts
+
+    def _parse_terminations(self, terminations):
+        parsed_terminations = torch.sigmoid(terminations).squeeze(-1).round().bool() if terminations is not None else None
+        return parsed_terminations
+
+    def _compute_imagination_reward_terms(self, parsed_imagination_states, rollout_action, parsed_extensions, parsed_contacts):
+        base_lin_vel = parsed_imagination_states["base_lin_vel"]
+        base_ang_vel = parsed_imagination_states["base_ang_vel"]
+        projected_gravity = parsed_imagination_states["projected_gravity"]
+        joint_pos = parsed_imagination_states["joint_pos"]
+        joint_vel = parsed_imagination_states["joint_vel"]
+        joint_torque = parsed_imagination_states["joint_torque"]
+        joint_acc = (joint_vel - self.last_obs["policy"][:, 12:24]) / self._step_dt
+        thigh_contact = parsed_contacts["thigh_contact"]
+        foot_contact = parsed_contacts["foot_contact"]
+
+        lin_vel_error = torch.sum(torch.square(self.base_velocity[:, :2] - base_lin_vel[:, :2]), dim=1)
+        ang_vel_error = torch.square(self.base_velocity[:, 2] - base_ang_vel[:, 2])
+
+        track_lin_vel_xy_exp = torch.exp(-lin_vel_error / 0.25)
+        track_ang_vel_z_exp = torch.exp(-ang_vel_error / 0.25)
+        lin_vel_z_l2 = torch.square(base_lin_vel[:, 2])
+        ang_vel_xy_l2 = torch.sum(torch.square(base_ang_vel[:, :2]), dim=1)
+        dof_torques_l2 = torch.sum(torch.square(joint_torque), dim=1)
+        dof_acc_l2 = torch.sum(torch.square(joint_acc), dim=1)
+        action_rate_l2 = torch.sum(torch.square(self.obs_last_action - rollout_action), dim=1)
+        if foot_contact is not None:
+            first_contact = (self.current_contact_time > 0.0) * (self.current_contact_time < (self._step_dt + 1.0e-8))
+            feet_air_time = torch.sum((self.last_air_time - 0.5) * first_contact, dim=1) * (torch.norm(self.base_velocity[:, :2], dim=1) > 0.1)
+
+            is_contact = foot_contact.bool()
+            is_first_contact = (self.current_air_time > 0) * is_contact
+            is_first_detached = (self.current_contact_time > 0) * ~is_contact
+            self.last_air_time = torch.where(
+                is_first_contact,
+                self.current_air_time + self._step_dt,
+                self.last_air_time,
+            )
+            self.current_air_time = torch.where(
+                ~is_contact, self.current_air_time + self._step_dt, 0.0
+            )
+            self.last_contact_time = torch.where(
+                is_first_detached,
+                self.current_contact_time + self._step_dt,
+                self.last_contact_time,
+            )
+            self.current_contact_time = torch.where(
+                is_contact, self.current_contact_time + self._step_dt, 0.0
+            )
+        else:
+            feet_air_time = torch.zeros(self.num_envs, device=self.device)
+        undesired_contacts = torch.sum(thigh_contact, dim=1) if thigh_contact is not None else torch.zeros(self.num_envs, device=self.device)
+        joint_pos_posture = torch.sum(torch.abs(joint_pos), dim=1)
+        stand_still = torch.sum(torch.abs(joint_pos), dim=1) * (torch.norm(self.base_velocity, dim=1) < 0.05)
+        flat_orientation_l2 = torch.sum(torch.square(projected_gravity[:, :2]), dim=1)
+        dof_pos_limits = torch.zeros(self.num_envs, device=self.device)
+        self.imagination_reward_per_step = {
+            "track_lin_vel_xy_exp": track_lin_vel_xy_exp,
+            "track_ang_vel_z_exp": track_ang_vel_z_exp,
+            "lin_vel_z_l2": lin_vel_z_l2,
+            "ang_vel_xy_l2": ang_vel_xy_l2,
+            "dof_torques_l2": dof_torques_l2,
+            "dof_acc_l2": dof_acc_l2,
+            "action_rate_l2": action_rate_l2,
+            "feet_air_time": feet_air_time,
+            "undesired_contacts": undesired_contacts,
+            "joint_pos_posture": joint_pos_posture,
+            "stand_still": stand_still,
+            "flat_orientation_l2": flat_orientation_l2,
+            "dof_pos_limits": dof_pos_limits,
+        }
+        last_obs = torch.cat([base_lin_vel, base_ang_vel, projected_gravity, self.base_velocity, joint_pos, joint_vel, rollout_action], dim=1)
+        self.last_obs = TensorDict({"policy": last_obs}, batch_size=[self.num_envs], device=self.device)
+
+    def _apply_interval_events(self, imagination_states_denormalized, parsed_imagination_states, event_ids):
+        if len(event_ids) == 0:
+            imagination_states, _ = self.dataset.normalize(imagination_states_denormalized, None)
+        else:
+            base_lin_vel = parsed_imagination_states["base_lin_vel"]
+            velocity_range = {"x": (-0.5, 0.5), "y": (-0.5, 0.5)}
+            r = torch.empty(len(event_ids), device=self.device)
+            base_lin_vel[event_ids, 0] += r.uniform_(*velocity_range["x"])
+            base_lin_vel[event_ids, 1] += r.uniform_(*velocity_range["y"])
+            imagination_states_denormalized[event_ids, 0:3] = base_lin_vel[event_ids, 0:3]
+            imagination_states, _ = self.dataset.normalize(imagination_states_denormalized, None)
+        return imagination_states
+
+    @property
+    def state_dim(self):
+        return 45
+
+    @property
+    def observation_dim(self):
+        return 48
+
+    @property
+    def action_dim(self):
+        return 12

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/policy_training.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/policy_training.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from rsl_rl.algorithms import PPO
+from envs.base import BaseEnv
+
+import os
+import statistics
+import time
+import torch
+from collections import deque
+import wandb
+
+
+class PolicyTraining:
+    def __init__(
+        self,
+        log_dir,
+        env: BaseEnv,
+        alg: PPO,
+        device,
+        num_steps_per_env=24,
+        save_interval=200,
+        max_iterations=1000,
+        export_dir=None,
+        ):
+        self.env = env
+        self.alg = alg
+        self.device = device
+        self.alg.init_storage(
+            "rl",
+            env.num_envs,
+            num_steps_per_env,
+            env.dummy_obs,
+            [env.action_dim],
+        )
+
+        self.num_steps_per_env = num_steps_per_env
+        self.save_interval = save_interval
+        self.max_iterations = max_iterations
+
+        self.log_dir = log_dir
+        self.export_dir = log_dir if export_dir is None else export_dir
+        self.tot_timesteps = 0
+        self.tot_time = 0
+        self.current_learning_iteration = 0
+
+    def learn(self):
+        state_history, action_history = self.env.prepare_imagination()
+        self.train_mode()
+
+        ep_infos = []
+        rewbuffer = deque(maxlen=100)
+        lenbuffer = deque(maxlen=100)
+        cur_reward_sum = torch.zeros(self.env.num_envs, dtype=torch.float, device=self.device)
+        cur_episode_length = torch.zeros(self.env.num_envs, dtype=torch.float, device=self.device)
+        
+        start_iter = self.current_learning_iteration
+        tot_iter = start_iter + self.max_iterations
+        for it in range(start_iter, tot_iter):
+            start = time.time()
+            self.log_dict = {}
+            epistemic_uncertainty = torch.zeros(self.num_steps_per_env, device=self.device)
+            with torch.inference_mode():
+                for i in range(self.num_steps_per_env):
+                    if self.env.system_dynamics.architecture_config["type"] in ["rnn", "rssm"] and self.env.common_step_counter > 0:
+                        state_history = state_history[:, -1:]
+                        action_history = action_history[:, -1:]
+                    imagination_obs = self.env.get_imagination_observation(state_history, action_history)
+                    imagination_actions = self.alg.act(imagination_obs)
+                    imagination_obs, imagination_rewards, imagination_dones, imagination_extras, state_history, action_history, uncertainty = self.env.imagination_step(imagination_actions, state_history, action_history)
+                    self.alg.process_env_step(imagination_obs, imagination_rewards, imagination_dones, imagination_extras)
+                    epistemic_uncertainty[i] = uncertainty.mean(dim=0)
+                    
+                    if self.log_dir is not None:
+                        if "episode" in imagination_extras:
+                            ep_infos.append(imagination_extras["episode"])
+                        elif "log" in imagination_extras:
+                            ep_infos.append(imagination_extras["log"])
+                        cur_reward_sum += imagination_rewards
+                        cur_episode_length += 1
+                        new_ids = (imagination_dones > 0).nonzero(as_tuple=False)
+                        rewbuffer.extend(cur_reward_sum[new_ids][:, 0].cpu().numpy().tolist())
+                        lenbuffer.extend(cur_episode_length[new_ids][:, 0].cpu().numpy().tolist())
+                        cur_reward_sum[new_ids] = 0
+                        cur_episode_length[new_ids] = 0
+
+                stop = time.time()
+                collection_time = stop - start
+                start = stop
+
+                # logs
+                num_valid_imagination_envs = self.alg.storage.valid_env_mask.sum()
+                epistemic_uncertainty = epistemic_uncertainty.mean(dim=0)
+                
+                self.log_dict.update({
+                    "Imagination/epistemic_uncertainty": epistemic_uncertainty,
+                    "Imagination/num_valid_imagination_envs": num_valid_imagination_envs,
+                    })
+
+                imagination_critic_obs = imagination_obs
+                self.alg.compute_returns(imagination_critic_obs)
+
+            # Update policy
+            # Note: we keep arguments here since locals() loads them
+            loss_dict = self.alg.update()
+            stop = time.time()
+            learn_time = stop - start
+            self.current_learning_iteration = it
+
+            # Logging info and save checkpoint
+            if self.log_dir is not None:
+                # Log information
+                self.log(locals())
+                # Save model
+                if it % self.save_interval == 0:
+                    self.save(os.path.join(self.log_dir, f"policy_{it}.pt"))
+
+            ep_infos.clear()
+        self.save(os.path.join(self.log_dir, f"policy_{it}.pt"))
+
+    def log(self, locs: dict, width: int = 80, pad: int = 35):
+        self.tot_timesteps += self.num_steps_per_env * self.env.num_envs
+        self.tot_time += locs["collection_time"] + locs["learn_time"]
+        iteration_time = locs["collection_time"] + locs["learn_time"]
+
+        # -- Episode info
+        ep_string = ""
+        if locs["ep_infos"]:
+            for key in locs["ep_infos"][0]:
+                infotensor = torch.tensor([], device=self.device)
+                for ep_info in locs["ep_infos"]:
+                    # handle scalar and zero dimensional tensor infos
+                    if key not in ep_info:
+                        continue
+                    if not isinstance(ep_info[key], torch.Tensor):
+                        ep_info[key] = torch.Tensor([ep_info[key]])
+                    if len(ep_info[key].shape) == 0:
+                        ep_info[key] = ep_info[key].unsqueeze(0)
+                    infotensor = torch.cat((infotensor, ep_info[key].to(self.device)))
+                value = torch.mean(infotensor)
+                # log to logger and terminal
+                self.log_dict.update({
+                    f"Imagination/{key}": value
+                })
+                ep_string += f"""{f'Mean episode {key}:':>{pad}} {value:.4f}\n"""
+
+        mean_std = self.alg.policy.std.mean()
+        fps = int(self.num_steps_per_env * self.env.num_envs / (locs["collection_time"] + locs["learn_time"]))
+        
+
+        # -- Losses
+        for key, value in locs["loss_dict"].items():
+            self.log_dict.update({
+                f"Loss/{key}": value
+                })
+        self.log_dict.update({
+            "Loss/policy_learning_rate": self.alg.learning_rate,
+            # -- Policy
+            "Policy/mean_noise_std": mean_std.item(),
+            # -- Performance
+            "Perf/total_fps": fps,
+            "Perf/collection time": locs["collection_time"],
+            "Perf/learning_time": locs["learn_time"],
+            })
+        if self.alg.rnd:
+            self.log_dict.update({
+                "Loss/rnd": locs["mean_rnd_loss"]
+                })
+        if self.alg.symmetry:
+            self.log_dict.update({
+                "Loss/symmetry": locs["mean_symmetry_loss"]
+                })
+        
+        # -- Training
+        if len(locs["rewbuffer"]) > 0:
+            self.log_dict.update({
+                "Train/mean_reward": statistics.mean(locs["rewbuffer"]),
+                "Train/mean_episode_length": statistics.mean(locs["lenbuffer"]),
+                "Loss/policy_learning_rate": self.alg.learning_rate,
+                "Policy/mean_noise_std": mean_std.item(),
+                "Perf/total_fps": fps,
+                "Perf/collection time": locs["collection_time"],
+                "Perf/learning_time": locs["learn_time"],
+                })
+        
+        wandb.log(self.log_dict)
+
+        str = f" \033[1m Learning iteration {locs['it']}/{locs['tot_iter']} \033[0m "
+
+        if len(locs["rewbuffer"]) > 0:
+            log_string = (
+                f"""{'#' * width}\n"""
+                f"""{str.center(width, ' ')}\n\n"""
+                f"""{'Computation:':>{pad}} {fps:.0f} steps/s (collection: {locs[
+                    'collection_time']:.3f}s, learning {locs['learn_time']:.3f}s)\n"""
+                f"""{'Mean action noise std:':>{pad}} {mean_std.item():.2f}\n"""
+            )
+            # -- Losses
+            for key, value in locs["loss_dict"].items():
+                log_string += f"""{f'Mean {key} loss:':>{pad}} {value:.4f}\n"""
+            # -- Rewards
+            if hasattr(self.alg, "rnd") and self.alg.rnd:
+                log_string += (
+                    f"""{'Mean extrinsic reward:':>{pad}} {statistics.mean(locs['erewbuffer']):.2f}\n"""
+                    f"""{'Mean intrinsic reward:':>{pad}} {statistics.mean(locs['irewbuffer']):.2f}\n"""
+                )
+            log_string += f"""{'Mean reward:':>{pad}} {statistics.mean(locs['rewbuffer']):.2f}\n"""
+            # -- episode info
+            log_string += f"""{'Mean episode length:':>{pad}} {statistics.mean(locs['lenbuffer']):.2f}\n"""
+        else:
+            log_string = (
+                f"""{'#' * width}\n"""
+                f"""{str.center(width, ' ')}\n\n"""
+                f"""{'Computation:':>{pad}} {fps:.0f} steps/s (collection: {locs[
+                    'collection_time']:.3f}s, learning {locs['learn_time']:.3f}s)\n"""
+                f"""{'Mean action noise std:':>{pad}} {mean_std.item():.2f}\n"""
+            )
+            for key, value in locs["loss_dict"].items():
+                log_string += f"""{f'{key}:':>{pad}} {value:.4f}\n"""
+
+        log_string += (
+            f"""{'-' * width}\n"""
+            f"""{'Total timesteps:':>{pad}} {self.tot_timesteps}\n"""
+            f"""{'Iteration time:':>{pad}} {iteration_time:.2f}s\n"""
+            f"""{'Time elapsed:':>{pad}} {time.strftime("%H:%M:%S", time.gmtime(self.tot_time))}\n"""
+            f"""{'ETA:':>{pad}} {time.strftime(
+                "%H:%M:%S",
+                time.gmtime(
+                    self.tot_time / (locs['it'] - locs['start_iter'] + 1)
+                    * (locs['start_iter'] + self.max_iterations - locs['it'])
+                )
+            )}\n"""
+        )
+        print(log_string)
+
+    def save(self, path, infos=None):
+        saved_dict = {
+            "model_state_dict": self.alg.policy.state_dict(),
+            "optimizer_state_dict": self.alg.optimizer.state_dict(),
+            "iter": self.current_learning_iteration,
+            "infos": infos,
+        }
+        torch.save(saved_dict, path)
+
+    def train_mode(self):
+        self.alg.policy.train()
+
+    def eval_mode(self):
+        self.alg.policy.eval()

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/train.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/train.py
@@ -1,0 +1,318 @@
+from configs import BaseConfig, AnymalDFlatConfig, Go2FlatConfig
+from envs import BaseEnv, AnymalDFlatEnv, Go2FlatEnv
+from policy_training import PolicyTraining
+from rsl_rl.modules import ActorCritic, SystemDynamicsEnsemble
+from rsl_rl.algorithms import PPO
+from rsl_rl.utils import resolve_obs_groups
+import os
+import torch
+from torch.utils.data import Dataset
+import argparse
+from datetime import datetime
+import time
+import pandas as pd
+import wandb
+
+
+class ModelBasedExperiment:
+      
+
+    def __init__(self, environment, device):
+        self.env_cls = self.resolve_environment_cls(environment)
+        self.device = device
+        self.data_file_idx = 0
+        
+    
+    def resolve_environment_cls(self, environment):
+        if environment == "anymal_d_flat":
+            return AnymalDFlatEnv
+        elif environment == "go2_flat":
+            return Go2FlatEnv
+        else:
+            raise ValueError(f"Unknown environment: {environment}")
+
+    
+    def _load_data(self, dataset_root, dataset_folder, file_data_size=10000, batch_data_size=50000):
+        batch_state_data = []
+        batch_action_data = []
+        batch_extension_data = []
+        batch_contact_data = []
+        batch_termination_data = []
+        batch_total_num_data = 0
+        while True:
+            try:
+                file = f"state_action_data_{self.data_file_idx}.csv"
+                data = pd.read_csv(os.path.join(dataset_root, dataset_folder, file), header=None)
+            except FileNotFoundError:
+                print(f"[Motion Loader] No data found in {os.path.join(dataset_root, dataset_folder, file)}. Waiting for new data.")
+                time.sleep(1)
+                continue
+            if len(data) < file_data_size:
+                print(f"[Motion Loader] Not enough data in {os.path.join(dataset_root, dataset_folder, file)}. Waiting for new data.")
+                time.sleep(1)
+                continue
+            else:
+                state_data = torch.tensor(data.iloc[:, :self.state_dim].values, dtype=torch.float32, device=self.device).unsqueeze(0)
+                action_data = torch.tensor(data.iloc[:, self.state_dim:self.state_dim + self.action_dim].values, dtype=torch.float32, device=self.device).unsqueeze(0)
+                extension_data = torch.tensor(data.iloc[:, self.state_dim + self.action_dim:self.state_dim + self.action_dim + self.extension_dim].values, dtype=torch.float32, device=self.device).unsqueeze(0)
+                contact_data = torch.tensor(data.iloc[:, self.state_dim + self.action_dim + self.extension_dim:self.state_dim + self.action_dim + self.extension_dim + self.contact_dim].values, dtype=torch.float32, device=self.device).unsqueeze(0)
+                termination_data = torch.tensor(data.iloc[:, self.state_dim + self.action_dim + self.extension_dim + self.contact_dim:].values, dtype=torch.float32, device=self.device).unsqueeze(0)
+                batch_state_data.append(state_data)
+                batch_action_data.append(action_data)
+                batch_extension_data.append(extension_data)
+                batch_contact_data.append(contact_data)
+                batch_termination_data.append(termination_data)
+                batch_total_num_data += len(data)
+                num_trajs, num_steps, state_dim = state_data.shape
+                print(f"[Motion Loader] Loaded {num_trajs} {dataset_folder} trajectories of {num_steps} steps from {file}.")
+                print(f"[Motion Loader] Total number of data: {batch_total_num_data} / {batch_data_size}")
+                self.data_file_idx += 1
+            if batch_total_num_data >= batch_data_size:
+                break
+        batch_state_data = torch.cat(batch_state_data, dim=1)
+        batch_action_data = torch.cat(batch_action_data, dim=1)
+        batch_extension_data = torch.cat(batch_extension_data, dim=1)
+        batch_contact_data = torch.cat(batch_contact_data, dim=1)
+        batch_termination_data = torch.cat(batch_termination_data, dim=1)
+        action_dim, extension_dim, contact_dim, termination_dim = action_data.shape[-1], extension_data.shape[-1], contact_data.shape[-1], termination_data.shape[-1]
+        print(f"[Motion Loader] State dim: {state_dim} | Action dim: {action_dim} | Extension dim: {extension_dim} | Contact dim: {contact_dim} | Termination dim: {termination_dim}")
+        return batch_state_data, batch_action_data, batch_extension_data, batch_contact_data, batch_termination_data
+    
+
+    def _build_eval_traj_config(self, eval_state_data, eval_action_data, eval_extension_data, eval_contact_data, eval_termination_data, num_eval_trajectories, num_visualizations, len_eval_trajectory, state_idx_dict):
+        num_eval_trajs, num_eval_steps, _ = eval_state_data.shape
+        ids = torch.randint(0, num_eval_trajs, (num_eval_trajectories,))
+        len_eval_trajectory = min(len_eval_trajectory, num_eval_steps)
+        start_steps = torch.randint(0, num_eval_steps - len_eval_trajectory + 1, (num_eval_trajectories,))
+        start_steps_expanded = start_steps[:, None] + torch.arange(len_eval_trajectory)
+        traj_data = [
+            eval_state_data[ids[:, None], start_steps_expanded],
+            eval_action_data[ids[:, None], start_steps_expanded],
+            eval_extension_data[ids[:, None], start_steps_expanded],
+            eval_contact_data[ids[:, None], start_steps_expanded],
+            eval_termination_data[ids[:, None], start_steps_expanded],
+            ]
+        self.eval_traj_config = {
+            "num_trajs": num_eval_trajectories,
+            "num_visualizations": num_visualizations,
+            "len_traj": len_eval_trajectory,
+            "traj_data": traj_data,
+            "state_idx_dict": state_idx_dict,
+        }
+
+
+    def prepare_environment(self, num_envs, max_episode_length, step_dt, reward_term_weights, uncertainty_penalty_weight, observation_noise, command_resample_interval_range, event_interval_range):
+        self.env: BaseEnv = self.env_cls(num_envs, max_episode_length, step_dt, reward_term_weights, self.device, uncertainty_penalty_weight, observation_noise, command_resample_interval_range, event_interval_range)
+
+
+    def prepare_data(self, dataset_root, dataset_folder, file_data_size, batch_data_size, state_data_mean=None, state_data_std=None, action_data_mean=None, action_data_std=None, init_data_ratio=0.0, num_eval_trajectories=100, num_visualizations=2, len_eval_trajectory=400, state_idx_dict=None):
+        state_data, action_data, extension_data, contact_data, termination_data = self._load_data(dataset_root, dataset_folder=dataset_folder, file_data_size=file_data_size, batch_data_size=batch_data_size)
+        self._build_eval_traj_config(state_data, action_data, extension_data, contact_data, termination_data, num_eval_trajectories, num_visualizations, len_eval_trajectory, state_idx_dict)
+        class SystemDynamicsDataset(Dataset):
+            def __init__(
+                self,
+                history_horizon,
+                forecast_horizon,
+                state_data,
+                action_data,
+                extension_data,
+                contact_data,
+                termination_data,
+                state_data_mean=None,
+                state_data_std=None,
+                action_data_mean=None,
+                action_data_std=None,
+                ):
+                self.history_horizon = history_horizon
+                self.forecast_horizon = forecast_horizon
+                
+                self.state_data_mean = torch.tensor(state_data_mean, device=state_data.device) if state_data_mean is not None else state_data.mean(dim=(0, 1))
+                self.state_data_std = torch.tensor(state_data_std, device=state_data.device) if state_data_std is not None else state_data.std(dim=(0, 1)) + 1e-6
+                self.action_data_mean = torch.tensor(action_data_mean, device=action_data.device) if action_data_mean is not None else action_data.mean(dim=(0, 1))
+                self.action_data_std = torch.tensor(action_data_std, device=action_data.device) if action_data_std is not None else action_data.std(dim=(0, 1)) + 1e-6
+                state_data, action_data = self.normalize(state_data, action_data)
+                
+                reset_indices = termination_data.flatten().nonzero(as_tuple=False).squeeze(-1)
+                if wandb.run is not None:
+                    wandb.log(
+                        {
+                            "Data/num_terminations": len(reset_indices),
+                            }
+                    )
+                valid_indices = []
+                for i in range(state_data.shape[1] - history_horizon - forecast_horizon + 1):
+                    if not any(reset_indices[(reset_indices >= i) & (reset_indices < i + history_horizon + forecast_horizon - 1)]):
+                        valid_indices.append(i)
+                # (num_groups, history_horizon + forecast_horizon, dim)
+                self.state_data = torch.cat([state_data[:, i:i + history_horizon + forecast_horizon, :] for i in valid_indices], dim=0)
+                self.action_data = torch.cat([action_data[:, i:i + history_horizon + forecast_horizon, :] for i in valid_indices], dim=0)
+                self.extension_data = torch.cat([extension_data[:, i:i + history_horizon + forecast_horizon, :] for i in valid_indices], dim=0)
+                self.contact_data = torch.cat([contact_data[:, i:i + history_horizon + forecast_horizon, :] for i in valid_indices], dim=0)
+                self.termination_data = torch.cat([termination_data[:, i:i + history_horizon + forecast_horizon, :] for i in valid_indices], dim=0)
+
+            def __len__(self):
+                return len(self.state_data)
+
+            def __getitem__(self, idx):
+                return self.state_data[idx], self.action_data[idx], self.extension_data[idx], self.contact_data[idx], self.termination_data[idx]
+            
+            def normalize(self, state_data=None, action_data=None):
+                state_data = (state_data - self.state_data_mean) / self.state_data_std if state_data is not None else None
+                action_data = (action_data - self.action_data_mean) / self.action_data_std if action_data is not None else None
+                return state_data, action_data
+            
+            def denormalize(self, state_data, action_data):
+                state_data = state_data * self.state_data_std + self.state_data_mean if state_data is not None else None
+                action_data = action_data * self.action_data_std + self.action_data_mean if action_data is not None else None
+                return state_data, action_data
+            
+            def sample_batch(self, batch_size, normalized=True):
+                idx = torch.randint(0, len(self.state_data), (batch_size,))
+                if normalized:
+                    return self.state_data[idx, :self.history_horizon], self.action_data[idx, :self.history_horizon]
+                else:
+                    return self.denormalize(self.state_data[idx, :self.history_horizon], self.action_data[idx, :self.history_horizon])
+            
+        self.dataset = SystemDynamicsDataset(
+            self.history_horizon,
+            self.forecast_horizon,
+            state_data,
+            action_data,
+            extension_data,
+            contact_data,
+            termination_data,
+            state_data_mean=state_data_mean,
+            state_data_std=state_data_std,
+            action_data_mean=action_data_mean,
+            action_data_std=action_data_std
+            )
+        # init env dataset
+        self.env.set_dataset(self.dataset)
+        if self.env.init_dataset is None:
+            self.env.set_init_dataset(self.dataset, init_data_ratio)
+
+
+    def prepare_model(self, history_horizon, forecast_horizon, extension_dim, contact_dim, termination_dim, ensemble_size, architecture_config, freeze_auxiliary=False, resume_path=None):
+        self.history_horizon = history_horizon
+        self.forecast_horizon = forecast_horizon
+        self.state_dim = self.env.state_dim
+        self.action_dim = self.env.action_dim
+        self.extension_dim = extension_dim
+        self.contact_dim = contact_dim
+        self.termination_dim = termination_dim
+        self.system_dynamics = SystemDynamicsEnsemble(
+            self.state_dim,
+            self.action_dim,
+            self.extension_dim,
+            self.contact_dim,
+            self.termination_dim,
+            self.device,
+            ensemble_size=ensemble_size,
+            history_horizon=self.history_horizon,
+            architecture_config=architecture_config,
+            freeze_auxiliary=freeze_auxiliary,
+            )
+        self.model_learning_iteration = 0
+        if resume_path is not None:
+            print(f"[Prepare Model] Loading model from {resume_path}.")
+            loaded_dict = torch.load(resume_path)
+            self.system_dynamics.load_state_dict(loaded_dict["system_dynamics_state_dict"])
+            self.model_learning_iteration = loaded_dict["iter"]
+        # init env system dynamics
+        self.env.set_system_dynamics(self.system_dynamics)
+            
+
+    def prepare_policy(self, observation_dim, obs_groups, action_dim, actor_hidden_dims, critic_hidden_dims, activation, init_noise_std, resume_path=None):
+        self.observation_dim = observation_dim
+        default_sets = ["critic"]
+        obs_groups = resolve_obs_groups(self.env.dummy_obs, obs_groups, default_sets)
+        self.actor_critic = ActorCritic(
+            obs=self.env.dummy_obs,
+            obs_groups=obs_groups,
+            num_actions=action_dim,
+            actor_hidden_dims=actor_hidden_dims,
+            critic_hidden_dims=critic_hidden_dims,
+            activation=activation,
+            init_noise_std=init_noise_std,
+            ).to(self.device)
+        self.policy_learning_iteration = 0
+        if resume_path is not None:
+            print(f"[Prepare Policy] Loading policy from {resume_path}.")
+            loaded_dict = torch.load(resume_path)
+            self.actor_critic.load_state_dict(loaded_dict["model_state_dict"])
+            self.policy_learning_iteration = loaded_dict["iter"]
+
+        
+    def prepare_algorithm(self, num_learning_epochs, num_mini_batches, clip_param, gamma, lam, value_loss_coef, entropy_coef, learning_rate, max_grad_norm, use_clipped_value_loss, schedule, desired_kl):
+        self.alg = PPO(
+            self.actor_critic,
+            num_learning_epochs,
+            num_mini_batches,
+            clip_param,
+            gamma,
+            lam,
+            value_loss_coef,
+            entropy_coef,
+            learning_rate,
+            max_grad_norm,
+            use_clipped_value_loss,
+            schedule,
+            desired_kl,
+            device=self.device,
+            )
+
+    
+    def train_policy(self, log_dir, num_steps_per_env, save_interval, max_iterations, export_dir):
+        print(f"[Train Policy] Training policy for {max_iterations} iterations.")
+        policy_training = PolicyTraining(
+            log_dir,
+            env=self.env,
+            alg=self.alg,
+            device=self.device,
+            num_steps_per_env=num_steps_per_env,
+            save_interval=save_interval,
+            max_iterations=max_iterations,
+            export_dir=export_dir,
+            )
+        policy_training.current_learning_iteration = self.policy_learning_iteration
+        policy_training.learn()
+        self.policy_learning_iteration += policy_training.max_iterations
+
+
+def run_experiment(config: BaseConfig):
+    run_name = datetime.now().strftime("%Y-%m-%d_%H-%M-%S") + f"_{args_cli.run_num}"
+    log_dir = os.path.join('logs', config.experiment_name, args_cli.task, run_name)
+    wandb.run.name = run_name
+    os.makedirs(log_dir, exist_ok=True)
+    model_experiment = ModelBasedExperiment(**config.experiment_config.to_dict())
+    model_experiment.prepare_environment(**config.environment_config.to_dict())
+    model_experiment.prepare_model(**config.model_architecture_config.to_dict())
+    model_experiment.prepare_policy(**config.policy_architecture_config.to_dict())
+    model_experiment.prepare_algorithm(**config.policy_algorithm_config.to_dict())
+    model_experiment.prepare_data(**config.data_config.to_dict())
+    model_experiment.train_policy(log_dir, **config.policy_training_config.to_dict())
+    print(f"Training completed. Policy saved to {log_dir}.")
+
+
+def run(config: BaseConfig):
+    wandb.init(project=config.experiment_name)
+    wandb.config.update(config.to_dict())
+    run_experiment(config)
+
+def resolve_task_config(task: str):
+    if task == "anymal_d_flat":
+        config = AnymalDFlatConfig()
+        return config
+    elif task == "go2_flat":
+        config = Go2FlatConfig()
+        return config
+    else:
+        raise ValueError(f"Unknown task: {task}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Online learning training.")
+    parser.add_argument("--task", type=str, default="anymal_d_flat", help="Task to use for the experiment.")
+    parser.add_argument("--run_num", type=int, default=None, help="Run number for the experiment on the cluster.")
+    args_cli = parser.parse_args()
+    config = resolve_task_config(args_cli.task)
+    run(config)

--- a/robotic_world_model/scripts/reinforcement_learning/model_based/utils/math.py
+++ b/robotic_world_model/scripts/reinforcement_learning/model_based/utils/math.py
@@ -1,0 +1,2002 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sub-module containing utilities for various math operations."""
+
+# needed to import for allowing type-hinting: torch.Tensor | np.ndarray
+from __future__ import annotations
+
+import math
+import numpy as np
+import torch
+import torch.nn.functional
+from typing import Literal
+
+import omni.log
+
+"""
+General
+"""
+
+
+@torch.jit.script
+def scale_transform(x: torch.Tensor, lower: torch.Tensor, upper: torch.Tensor) -> torch.Tensor:
+    """Normalizes a given input tensor to a range of [-1, 1].
+
+    .. note::
+        It uses pytorch broadcasting functionality to deal with batched input.
+
+    Args:
+        x: Input tensor of shape (N, dims).
+        lower: The minimum value of the tensor. Shape is (N, dims) or (dims,).
+        upper: The maximum value of the tensor. Shape is (N, dims) or (dims,).
+
+    Returns:
+        Normalized transform of the tensor. Shape is (N, dims).
+    """
+    # default value of center
+    offset = (lower + upper) * 0.5
+    # return normalized tensor
+    return 2 * (x - offset) / (upper - lower)
+
+
+@torch.jit.script
+def unscale_transform(x: torch.Tensor, lower: torch.Tensor, upper: torch.Tensor) -> torch.Tensor:
+    """De-normalizes a given input tensor from range of [-1, 1] to (lower, upper).
+
+    .. note::
+        It uses pytorch broadcasting functionality to deal with batched input.
+
+    Args:
+        x: Input tensor of shape (N, dims).
+        lower: The minimum value of the tensor. Shape is (N, dims) or (dims,).
+        upper: The maximum value of the tensor. Shape is (N, dims) or (dims,).
+
+    Returns:
+        De-normalized transform of the tensor. Shape is (N, dims).
+    """
+    # default value of center
+    offset = (lower + upper) * 0.5
+    # return normalized tensor
+    return x * (upper - lower) * 0.5 + offset
+
+
+@torch.jit.script
+def saturate(x: torch.Tensor, lower: torch.Tensor, upper: torch.Tensor) -> torch.Tensor:
+    """Clamps a given input tensor to (lower, upper).
+
+    It uses pytorch broadcasting functionality to deal with batched input.
+
+    Args:
+        x: Input tensor of shape (N, dims).
+        lower: The minimum value of the tensor. Shape is (N, dims) or (dims,).
+        upper: The maximum value of the tensor. Shape is (N, dims) or (dims,).
+
+    Returns:
+        Clamped transform of the tensor. Shape is (N, dims).
+    """
+    return torch.max(torch.min(x, upper), lower)
+
+
+@torch.jit.script
+def normalize(x: torch.Tensor, eps: float = 1e-9) -> torch.Tensor:
+    """Normalizes a given input tensor to unit length.
+
+    Args:
+        x: Input tensor of shape (N, dims).
+        eps: A small value to avoid division by zero. Defaults to 1e-9.
+
+    Returns:
+        Normalized tensor of shape (N, dims).
+    """
+    return x / x.norm(p=2, dim=-1).clamp(min=eps, max=None).unsqueeze(-1)
+
+
+@torch.jit.script
+def wrap_to_pi(angles: torch.Tensor) -> torch.Tensor:
+    r"""Wraps input angles (in radians) to the range :math:`[-\pi, \pi]`.
+
+    This function wraps angles in radians to the range :math:`[-\pi, \pi]`, such that
+    :math:`\pi` maps to :math:`\pi`, and :math:`-\pi` maps to :math:`-\pi`. In general,
+    odd positive multiples of :math:`\pi` are mapped to :math:`\pi`, and odd negative
+    multiples of :math:`\pi` are mapped to :math:`-\pi`.
+
+    The function behaves similar to MATLAB's `wrapToPi <https://www.mathworks.com/help/map/ref/wraptopi.html>`_
+    function.
+
+    Args:
+        angles: Input angles of any shape.
+
+    Returns:
+        Angles in the range :math:`[-\pi, \pi]`.
+    """
+    # wrap to [0, 2*pi)
+    wrapped_angle = (angles + torch.pi) % (2 * torch.pi)
+    # map to [-pi, pi]
+    # we check for zero in wrapped angle to make it go to pi when input angle is odd multiple of pi
+    return torch.where((wrapped_angle == 0) & (angles > 0), torch.pi, wrapped_angle - torch.pi)
+
+
+@torch.jit.script
+def copysign(mag: float, other: torch.Tensor) -> torch.Tensor:
+    """Create a new floating-point tensor with the magnitude of input and the sign of other, element-wise.
+
+    Note:
+        The implementation follows from `torch.copysign`. The function allows a scalar magnitude.
+
+    Args:
+        mag: The magnitude scalar.
+        other: The tensor containing values whose signbits are applied to magnitude.
+
+    Returns:
+        The output tensor.
+    """
+    mag_torch = abs(mag) * torch.ones_like(other)
+    return torch.copysign(mag_torch, other)
+
+
+"""
+Rotation
+"""
+
+
+@torch.jit.script
+def quat_unique(q: torch.Tensor) -> torch.Tensor:
+    """Convert a unit quaternion to a standard form where the real part is non-negative.
+
+    Quaternion representations have a singularity since ``q`` and ``-q`` represent the same
+    rotation. This function ensures the real part of the quaternion is non-negative.
+
+    Args:
+        q: The quaternion orientation in (w, x, y, z). Shape is (..., 4).
+
+    Returns:
+        Standardized quaternions. Shape is (..., 4).
+    """
+    return torch.where(q[..., 0:1] < 0, -q, q)
+
+
+@torch.jit.script
+def matrix_from_quat(quaternions: torch.Tensor) -> torch.Tensor:
+    """Convert rotations given as quaternions to rotation matrices.
+
+    Args:
+        quaternions: The quaternion orientation in (w, x, y, z). Shape is (..., 4).
+
+    Returns:
+        Rotation matrices. The shape is (..., 3, 3).
+
+    Reference:
+        https://github.com/facebookresearch/pytorch3d/blob/main/pytorch3d/transforms/rotation_conversions.py#L41-L70
+    """
+    r, i, j, k = torch.unbind(quaternions, -1)
+    # pyre-fixme[58]: `/` is not supported for operand types `float` and `Tensor`.
+    two_s = 2.0 / (quaternions * quaternions).sum(-1)
+
+    o = torch.stack(
+        (
+            1 - two_s * (j * j + k * k),
+            two_s * (i * j - k * r),
+            two_s * (i * k + j * r),
+            two_s * (i * j + k * r),
+            1 - two_s * (i * i + k * k),
+            two_s * (j * k - i * r),
+            two_s * (i * k - j * r),
+            two_s * (j * k + i * r),
+            1 - two_s * (i * i + j * j),
+        ),
+        -1,
+    )
+    return o.reshape(quaternions.shape[:-1] + (3, 3))
+
+
+def convert_quat(quat: torch.Tensor | np.ndarray, to: Literal["xyzw", "wxyz"] = "xyzw") -> torch.Tensor | np.ndarray:
+    """Converts quaternion from one convention to another.
+
+    The convention to convert TO is specified as an optional argument. If to == 'xyzw',
+    then the input is in 'wxyz' format, and vice-versa.
+
+    Args:
+        quat: The quaternion of shape (..., 4).
+        to: Convention to convert quaternion to.. Defaults to "xyzw".
+
+    Returns:
+        The converted quaternion in specified convention.
+
+    Raises:
+        ValueError: Invalid input argument `to`, i.e. not "xyzw" or "wxyz".
+        ValueError: Invalid shape of input `quat`, i.e. not (..., 4,).
+    """
+    # check input is correct
+    if quat.shape[-1] != 4:
+        msg = f"Expected input quaternion shape mismatch: {quat.shape} != (..., 4)."
+        raise ValueError(msg)
+    if to not in ["xyzw", "wxyz"]:
+        msg = f"Expected input argument `to` to be 'xyzw' or 'wxyz'. Received: {to}."
+        raise ValueError(msg)
+    # check if input is numpy array (we support this backend since some classes use numpy)
+    if isinstance(quat, np.ndarray):
+        # use numpy functions
+        if to == "xyzw":
+            # wxyz -> xyzw
+            return np.roll(quat, -1, axis=-1)
+        else:
+            # xyzw -> wxyz
+            return np.roll(quat, 1, axis=-1)
+    else:
+        # convert to torch (sanity check)
+        if not isinstance(quat, torch.Tensor):
+            quat = torch.tensor(quat, dtype=float)
+        # convert to specified quaternion type
+        if to == "xyzw":
+            # wxyz -> xyzw
+            return quat.roll(-1, dims=-1)
+        else:
+            # xyzw -> wxyz
+            return quat.roll(1, dims=-1)
+
+
+@torch.jit.script
+def quat_conjugate(q: torch.Tensor) -> torch.Tensor:
+    """Computes the conjugate of a quaternion.
+
+    Args:
+        q: The quaternion orientation in (w, x, y, z). Shape is (..., 4).
+
+    Returns:
+        The conjugate quaternion in (w, x, y, z). Shape is (..., 4).
+    """
+    shape = q.shape
+    q = q.reshape(-1, 4)
+    return torch.cat((q[..., 0:1], -q[..., 1:]), dim=-1).view(shape)
+
+
+@torch.jit.script
+def quat_inv(q: torch.Tensor, eps: float = 1e-9) -> torch.Tensor:
+    """Computes the inverse of a quaternion.
+
+    Args:
+        q: The quaternion orientation in (w, x, y, z). Shape is (N, 4).
+        eps: A small value to avoid division by zero. Defaults to 1e-9.
+
+    Returns:
+        The inverse quaternion in (w, x, y, z). Shape is (N, 4).
+    """
+    return quat_conjugate(q) / q.pow(2).sum(dim=-1, keepdim=True).clamp(min=eps)
+
+
+@torch.jit.script
+def quat_from_euler_xyz(roll: torch.Tensor, pitch: torch.Tensor, yaw: torch.Tensor) -> torch.Tensor:
+    """Convert rotations given as Euler angles in radians to Quaternions.
+
+    Note:
+        The euler angles are assumed in XYZ convention.
+
+    Args:
+        roll: Rotation around x-axis (in radians). Shape is (N,).
+        pitch: Rotation around y-axis (in radians). Shape is (N,).
+        yaw: Rotation around z-axis (in radians). Shape is (N,).
+
+    Returns:
+        The quaternion in (w, x, y, z). Shape is (N, 4).
+    """
+    cy = torch.cos(yaw * 0.5)
+    sy = torch.sin(yaw * 0.5)
+    cr = torch.cos(roll * 0.5)
+    sr = torch.sin(roll * 0.5)
+    cp = torch.cos(pitch * 0.5)
+    sp = torch.sin(pitch * 0.5)
+    # compute quaternion
+    qw = cy * cr * cp + sy * sr * sp
+    qx = cy * sr * cp - sy * cr * sp
+    qy = cy * cr * sp + sy * sr * cp
+    qz = sy * cr * cp - cy * sr * sp
+
+    return torch.stack([qw, qx, qy, qz], dim=-1)
+
+
+@torch.jit.script
+def _sqrt_positive_part(x: torch.Tensor) -> torch.Tensor:
+    """Returns torch.sqrt(torch.max(0, x)) but with a zero sub-gradient where x is 0.
+
+    Reference:
+        https://github.com/facebookresearch/pytorch3d/blob/main/pytorch3d/transforms/rotation_conversions.py#L91-L99
+    """
+    ret = torch.zeros_like(x)
+    positive_mask = x > 0
+    ret[positive_mask] = torch.sqrt(x[positive_mask])
+    return ret
+
+
+@torch.jit.script
+def quat_from_matrix(matrix: torch.Tensor) -> torch.Tensor:
+    """Convert rotations given as rotation matrices to quaternions.
+
+    Args:
+        matrix: The rotation matrices. Shape is (..., 3, 3).
+
+    Returns:
+        The quaternion in (w, x, y, z). Shape is (..., 4).
+
+    Reference:
+        https://github.com/facebookresearch/pytorch3d/blob/main/pytorch3d/transforms/rotation_conversions.py#L102-L161
+    """
+    if matrix.size(-1) != 3 or matrix.size(-2) != 3:
+        raise ValueError(f"Invalid rotation matrix shape {matrix.shape}.")
+
+    batch_dim = matrix.shape[:-2]
+    m00, m01, m02, m10, m11, m12, m20, m21, m22 = torch.unbind(matrix.reshape(batch_dim + (9,)), dim=-1)
+
+    q_abs = _sqrt_positive_part(
+        torch.stack(
+            [
+                1.0 + m00 + m11 + m22,
+                1.0 + m00 - m11 - m22,
+                1.0 - m00 + m11 - m22,
+                1.0 - m00 - m11 + m22,
+            ],
+            dim=-1,
+        )
+    )
+
+    # we produce the desired quaternion multiplied by each of r, i, j, k
+    quat_by_rijk = torch.stack(
+        [
+            # pyre-fixme[58]: `**` is not supported for operand types `Tensor` and `int`.
+            torch.stack([q_abs[..., 0] ** 2, m21 - m12, m02 - m20, m10 - m01], dim=-1),
+            # pyre-fixme[58]: `**` is not supported for operand types `Tensor` and `int`.
+            torch.stack([m21 - m12, q_abs[..., 1] ** 2, m10 + m01, m02 + m20], dim=-1),
+            # pyre-fixme[58]: `**` is not supported for operand types `Tensor` and `int`.
+            torch.stack([m02 - m20, m10 + m01, q_abs[..., 2] ** 2, m12 + m21], dim=-1),
+            # pyre-fixme[58]: `**` is not supported for operand types `Tensor` and `int`.
+            torch.stack([m10 - m01, m20 + m02, m21 + m12, q_abs[..., 3] ** 2], dim=-1),
+        ],
+        dim=-2,
+    )
+
+    # We floor here at 0.1 but the exact level is not important; if q_abs is small,
+    # the candidate won't be picked.
+    flr = torch.tensor(0.1).to(dtype=q_abs.dtype, device=q_abs.device)
+    quat_candidates = quat_by_rijk / (2.0 * q_abs[..., None].max(flr))
+
+    # if not for numerical problems, quat_candidates[i] should be same (up to a sign),
+    # forall i; we pick the best-conditioned one (with the largest denominator)
+    return quat_candidates[torch.nn.functional.one_hot(q_abs.argmax(dim=-1), num_classes=4) > 0.5, :].reshape(
+        batch_dim + (4,)
+    )
+
+
+def _axis_angle_rotation(axis: Literal["X", "Y", "Z"], angle: torch.Tensor) -> torch.Tensor:
+    """Return the rotation matrices for one of the rotations about an axis of which Euler angles describe,
+    for each value of the angle given.
+
+    Args:
+        axis: Axis label "X" or "Y or "Z".
+        angle: Euler angles in radians of any shape.
+
+    Returns:
+        Rotation matrices. Shape is (..., 3, 3).
+
+    Reference:
+        https://github.com/facebookresearch/pytorch3d/blob/main/pytorch3d/transforms/rotation_conversions.py#L164-L191
+    """
+    cos = torch.cos(angle)
+    sin = torch.sin(angle)
+    one = torch.ones_like(angle)
+    zero = torch.zeros_like(angle)
+
+    if axis == "X":
+        R_flat = (one, zero, zero, zero, cos, -sin, zero, sin, cos)
+    elif axis == "Y":
+        R_flat = (cos, zero, sin, zero, one, zero, -sin, zero, cos)
+    elif axis == "Z":
+        R_flat = (cos, -sin, zero, sin, cos, zero, zero, zero, one)
+    else:
+        raise ValueError("letter must be either X, Y or Z.")
+
+    return torch.stack(R_flat, -1).reshape(angle.shape + (3, 3))
+
+
+def matrix_from_euler(euler_angles: torch.Tensor, convention: str) -> torch.Tensor:
+    """
+    Convert rotations given as Euler angles (intrinsic) in radians to rotation matrices.
+
+    Args:
+        euler_angles: Euler angles in radians. Shape is (..., 3).
+        convention: Convention string of three uppercase letters from {"X", "Y", and "Z"}.
+            For example, "XYZ" means that the rotations should be applied first about x,
+            then y, then z.
+
+    Returns:
+        Rotation matrices. Shape is (..., 3, 3).
+
+    Reference:
+        https://github.com/facebookresearch/pytorch3d/blob/main/pytorch3d/transforms/rotation_conversions.py#L194-L220
+    """
+    if euler_angles.dim() == 0 or euler_angles.shape[-1] != 3:
+        raise ValueError("Invalid input euler angles.")
+    if len(convention) != 3:
+        raise ValueError("Convention must have 3 letters.")
+    if convention[1] in (convention[0], convention[2]):
+        raise ValueError(f"Invalid convention {convention}.")
+    for letter in convention:
+        if letter not in ("X", "Y", "Z"):
+            raise ValueError(f"Invalid letter {letter} in convention string.")
+    matrices = [_axis_angle_rotation(c, e) for c, e in zip(convention, torch.unbind(euler_angles, -1))]
+    # return functools.reduce(torch.matmul, matrices)
+    return torch.matmul(torch.matmul(matrices[0], matrices[1]), matrices[2])
+
+
+@torch.jit.script
+def euler_xyz_from_quat(
+    quat: torch.Tensor, wrap_to_2pi: bool = False
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Convert rotations given as quaternions to Euler angles in radians.
+
+    Note:
+        The euler angles are assumed in XYZ extrinsic convention.
+
+    Args:
+        quat: The quaternion orientation in (w, x, y, z). Shape is (N, 4).
+        wrap_to_2pi (bool): Whether to wrap output Euler angles into [0, 2π). If
+            False, angles are returned in the default range (−π, π]. Defaults to
+            False.
+
+    Returns:
+        A tuple containing roll-pitch-yaw. Each element is a tensor of shape (N,).
+
+    Reference:
+        https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+    """
+    q_w, q_x, q_y, q_z = quat[:, 0], quat[:, 1], quat[:, 2], quat[:, 3]
+    # roll (x-axis rotation)
+    sin_roll = 2.0 * (q_w * q_x + q_y * q_z)
+    cos_roll = 1 - 2 * (q_x * q_x + q_y * q_y)
+    roll = torch.atan2(sin_roll, cos_roll)
+
+    # pitch (y-axis rotation)
+    sin_pitch = 2.0 * (q_w * q_y - q_z * q_x)
+    pitch = torch.where(torch.abs(sin_pitch) >= 1, copysign(torch.pi / 2.0, sin_pitch), torch.asin(sin_pitch))
+
+    # yaw (z-axis rotation)
+    sin_yaw = 2.0 * (q_w * q_z + q_x * q_y)
+    cos_yaw = 1 - 2 * (q_y * q_y + q_z * q_z)
+    yaw = torch.atan2(sin_yaw, cos_yaw)
+
+    if wrap_to_2pi:
+        return roll % (2 * torch.pi), pitch % (2 * torch.pi), yaw % (2 * torch.pi)
+    return roll, pitch, yaw
+
+
+@torch.jit.script
+def axis_angle_from_quat(quat: torch.Tensor, eps: float = 1.0e-6) -> torch.Tensor:
+    """Convert rotations given as quaternions to axis/angle.
+
+    Args:
+        quat: The quaternion orientation in (w, x, y, z). Shape is (..., 4).
+        eps: The tolerance for Taylor approximation. Defaults to 1.0e-6.
+
+    Returns:
+        Rotations given as a vector in axis angle form. Shape is (..., 3).
+        The vector's magnitude is the angle turned anti-clockwise in radians around the vector's direction.
+
+    Reference:
+        https://github.com/facebookresearch/pytorch3d/blob/main/pytorch3d/transforms/rotation_conversions.py#L526-L554
+    """
+    # Modified to take in quat as [q_w, q_x, q_y, q_z]
+    # Quaternion is [q_w, q_x, q_y, q_z] = [cos(theta/2), n_x * sin(theta/2), n_y * sin(theta/2), n_z * sin(theta/2)]
+    # Axis-angle is [a_x, a_y, a_z] = [theta * n_x, theta * n_y, theta * n_z]
+    # Thus, axis-angle is [q_x, q_y, q_z] / (sin(theta/2) / theta)
+    # When theta = 0, (sin(theta/2) / theta) is undefined
+    # However, as theta --> 0, we can use the Taylor approximation 1/2 - theta^2 / 48
+    quat = quat * (1.0 - 2.0 * (quat[..., 0:1] < 0.0))
+    mag = torch.linalg.norm(quat[..., 1:], dim=-1)
+    half_angle = torch.atan2(mag, quat[..., 0])
+    angle = 2.0 * half_angle
+    # check whether to apply Taylor approximation
+    sin_half_angles_over_angles = torch.where(
+        angle.abs() > eps, torch.sin(half_angle) / angle, 0.5 - angle * angle / 48
+    )
+    return quat[..., 1:4] / sin_half_angles_over_angles.unsqueeze(-1)
+
+
+@torch.jit.script
+def quat_from_angle_axis(angle: torch.Tensor, axis: torch.Tensor) -> torch.Tensor:
+    """Convert rotations given as angle-axis to quaternions.
+
+    Args:
+        angle: The angle turned anti-clockwise in radians around the vector's direction. Shape is (N,).
+        axis: The axis of rotation. Shape is (N, 3).
+
+    Returns:
+        The quaternion in (w, x, y, z). Shape is (N, 4).
+    """
+    theta = (angle / 2).unsqueeze(-1)
+    xyz = normalize(axis) * theta.sin()
+    w = theta.cos()
+    return normalize(torch.cat([w, xyz], dim=-1))
+
+
+@torch.jit.script
+def quat_mul(q1: torch.Tensor, q2: torch.Tensor) -> torch.Tensor:
+    """Multiply two quaternions together.
+
+    Args:
+        q1: The first quaternion in (w, x, y, z). Shape is (..., 4).
+        q2: The second quaternion in (w, x, y, z). Shape is (..., 4).
+
+    Returns:
+        The product of the two quaternions in (w, x, y, z). Shape is (..., 4).
+
+    Raises:
+        ValueError: Input shapes of ``q1`` and ``q2`` are not matching.
+    """
+    # check input is correct
+    if q1.shape != q2.shape:
+        msg = f"Expected input quaternion shape mismatch: {q1.shape} != {q2.shape}."
+        raise ValueError(msg)
+    # reshape to (N, 4) for multiplication
+    shape = q1.shape
+    q1 = q1.reshape(-1, 4)
+    q2 = q2.reshape(-1, 4)
+    # extract components from quaternions
+    w1, x1, y1, z1 = q1[:, 0], q1[:, 1], q1[:, 2], q1[:, 3]
+    w2, x2, y2, z2 = q2[:, 0], q2[:, 1], q2[:, 2], q2[:, 3]
+    # perform multiplication
+    ww = (z1 + x1) * (x2 + y2)
+    yy = (w1 - y1) * (w2 + z2)
+    zz = (w1 + y1) * (w2 - z2)
+    xx = ww + yy + zz
+    qq = 0.5 * (xx + (z1 - x1) * (x2 - y2))
+    w = qq - ww + (z1 - y1) * (y2 - z2)
+    x = qq - xx + (x1 + w1) * (x2 + w2)
+    y = qq - yy + (w1 - x1) * (y2 + z2)
+    z = qq - zz + (z1 + y1) * (w2 - x2)
+
+    return torch.stack([w, x, y, z], dim=-1).view(shape)
+
+
+@torch.jit.script
+def yaw_quat(quat: torch.Tensor) -> torch.Tensor:
+    """Extract the yaw component of a quaternion.
+
+    Args:
+        quat: The orientation in (w, x, y, z). Shape is (..., 4)
+
+    Returns:
+        A quaternion with only yaw component.
+    """
+    shape = quat.shape
+    quat_yaw = quat.view(-1, 4)
+    qw = quat_yaw[:, 0]
+    qx = quat_yaw[:, 1]
+    qy = quat_yaw[:, 2]
+    qz = quat_yaw[:, 3]
+    yaw = torch.atan2(2 * (qw * qz + qx * qy), 1 - 2 * (qy * qy + qz * qz))
+    quat_yaw = torch.zeros_like(quat_yaw)
+    quat_yaw[:, 3] = torch.sin(yaw / 2)
+    quat_yaw[:, 0] = torch.cos(yaw / 2)
+    quat_yaw = normalize(quat_yaw)
+    return quat_yaw.view(shape)
+
+
+@torch.jit.script
+def quat_box_minus(q1: torch.Tensor, q2: torch.Tensor) -> torch.Tensor:
+    """The box-minus operator (quaternion difference) between two quaternions.
+
+    Args:
+        q1: The first quaternion in (w, x, y, z). Shape is (N, 4).
+        q2: The second quaternion in (w, x, y, z). Shape is (N, 4).
+
+    Returns:
+        The difference between the two quaternions. Shape is (N, 3).
+
+    Reference:
+        https://github.com/ANYbotics/kindr/blob/master/doc/cheatsheet/cheatsheet_latest.pdf
+    """
+    quat_diff = quat_mul(q1, quat_conjugate(q2))  # q1 * q2^-1
+    return axis_angle_from_quat(quat_diff)  # log(qd)
+
+
+@torch.jit.script
+def quat_box_plus(q: torch.Tensor, delta: torch.Tensor, eps: float = 1.0e-6) -> torch.Tensor:
+    """The box-plus operator (quaternion update) to apply an increment to a quaternion.
+
+    Args:
+        q: The initial quaternion in (w, x, y, z). Shape is (N, 4).
+        delta: The axis-angle perturbation. Shape is (N, 3).
+            eps: A small value to avoid division by zero. Defaults to 1e-6.
+
+    Returns:
+        The updated quaternion after applying the perturbation. Shape is (N, 4).
+
+    Reference:
+        https://github.com/ANYbotics/kindr/blob/master/doc/cheatsheet/cheatsheet_latest.pdf
+    """
+    delta_norm = torch.clamp_min(torch.linalg.norm(delta, dim=-1, keepdim=True), min=eps)
+    delta_quat = quat_from_angle_axis(delta_norm.squeeze(-1), delta / delta_norm)  # exp(dq)
+    new_quat = quat_mul(delta_quat, q)  # Apply perturbation
+    return quat_unique(new_quat)
+
+
+@torch.jit.script
+def quat_apply(quat: torch.Tensor, vec: torch.Tensor) -> torch.Tensor:
+    """Apply a quaternion rotation to a vector.
+
+    Args:
+        quat: The quaternion in (w, x, y, z). Shape is (..., 4).
+        vec: The vector in (x, y, z). Shape is (..., 3).
+
+    Returns:
+        The rotated vector in (x, y, z). Shape is (..., 3).
+    """
+    # store shape
+    shape = vec.shape
+    # reshape to (N, 3) for multiplication
+    quat = quat.reshape(-1, 4)
+    vec = vec.reshape(-1, 3)
+    # extract components from quaternions
+    xyz = quat[:, 1:]
+    t = xyz.cross(vec, dim=-1) * 2
+    return (vec + quat[:, 0:1] * t + xyz.cross(t, dim=-1)).view(shape)
+
+
+@torch.jit.script
+def quat_apply_inverse(quat: torch.Tensor, vec: torch.Tensor) -> torch.Tensor:
+    """Apply an inverse quaternion rotation to a vector.
+
+    Args:
+        quat: The quaternion in (w, x, y, z). Shape is (..., 4).
+        vec: The vector in (x, y, z). Shape is (..., 3).
+
+    Returns:
+        The rotated vector in (x, y, z). Shape is (..., 3).
+    """
+    # store shape
+    shape = vec.shape
+    # reshape to (N, 3) for multiplication
+    quat = quat.reshape(-1, 4)
+    vec = vec.reshape(-1, 3)
+    # extract components from quaternions
+    xyz = quat[:, 1:]
+    t = xyz.cross(vec, dim=-1) * 2
+    return (vec - quat[:, 0:1] * t + xyz.cross(t, dim=-1)).view(shape)
+
+
+@torch.jit.script
+def quat_apply_yaw(quat: torch.Tensor, vec: torch.Tensor) -> torch.Tensor:
+    """Rotate a vector only around the yaw-direction.
+
+    Args:
+        quat: The orientation in (w, x, y, z). Shape is (N, 4).
+        vec: The vector in (x, y, z). Shape is (N, 3).
+
+    Returns:
+        The rotated vector in (x, y, z). Shape is (N, 3).
+    """
+    quat_yaw = yaw_quat(quat)
+    return quat_apply(quat_yaw, vec)
+
+
+def quat_rotate(q: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    """Rotate a vector by a quaternion along the last dimension of q and v.
+    .. deprecated v2.1.0:
+         This function will be removed in a future release in favor of the faster implementation :meth:`quat_apply`.
+
+    Args:
+        q: The quaternion in (w, x, y, z). Shape is (..., 4).
+        v: The vector in (x, y, z). Shape is (..., 3).
+
+    Returns:
+        The rotated vector in (x, y, z). Shape is (..., 3).
+    """
+    # deprecation
+    omni.log.warn(
+        "The function 'quat_rotate' will be deprecated in favor of the faster method 'quat_apply'."
+        " Please use 'quat_apply' instead...."
+    )
+    return quat_apply(q, v)
+
+
+def quat_rotate_inverse(q: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    """Rotate a vector by the inverse of a quaternion along the last dimension of q and v.
+
+    .. deprecated v2.1.0:
+         This function will be removed in a future release in favor of the faster implementation :meth:`quat_apply_inverse`.
+    Args:
+        q: The quaternion in (w, x, y, z). Shape is (..., 4).
+        v: The vector in (x, y, z). Shape is (..., 3).
+
+    Returns:
+        The rotated vector in (x, y, z). Shape is (..., 3).
+    """
+    omni.log.warn(
+        "The function 'quat_rotate_inverse' will be deprecated in favor of the faster method 'quat_apply_inverse'."
+        " Please use 'quat_apply_inverse' instead...."
+    )
+    return quat_apply_inverse(q, v)
+
+
+@torch.jit.script
+def quat_error_magnitude(q1: torch.Tensor, q2: torch.Tensor) -> torch.Tensor:
+    """Computes the rotation difference between two quaternions.
+
+    Args:
+        q1: The first quaternion in (w, x, y, z). Shape is (..., 4).
+        q2: The second quaternion in (w, x, y, z). Shape is (..., 4).
+
+    Returns:
+        Angular error between input quaternions in radians.
+    """
+    axis_angle_error = quat_box_minus(q1, q2)
+    return torch.norm(axis_angle_error, dim=-1)
+
+
+@torch.jit.script
+def skew_symmetric_matrix(vec: torch.Tensor) -> torch.Tensor:
+    """Computes the skew-symmetric matrix of a vector.
+
+    Args:
+        vec: The input vector. Shape is (3,) or (N, 3).
+
+    Returns:
+        The skew-symmetric matrix. Shape is (1, 3, 3) or (N, 3, 3).
+
+    Raises:
+        ValueError: If input tensor is not of shape (..., 3).
+    """
+    # check input is correct
+    if vec.shape[-1] != 3:
+        raise ValueError(f"Expected input vector shape mismatch: {vec.shape} != (..., 3).")
+    # unsqueeze the last dimension
+    if vec.ndim == 1:
+        vec = vec.unsqueeze(0)
+    # create a skew-symmetric matrix
+    skew_sym_mat = torch.zeros(vec.shape[0], 3, 3, device=vec.device, dtype=vec.dtype)
+    skew_sym_mat[:, 0, 1] = -vec[:, 2]
+    skew_sym_mat[:, 0, 2] = vec[:, 1]
+    skew_sym_mat[:, 1, 2] = -vec[:, 0]
+    skew_sym_mat[:, 1, 0] = vec[:, 2]
+    skew_sym_mat[:, 2, 0] = -vec[:, 1]
+    skew_sym_mat[:, 2, 1] = vec[:, 0]
+
+    return skew_sym_mat
+
+
+"""
+Transformations
+"""
+
+
+def is_identity_pose(pos: torch.tensor, rot: torch.tensor) -> bool:
+    """Checks if input poses are identity transforms.
+
+    The function checks if the input position and orientation are close to zero and
+    identity respectively using L2-norm. It does NOT check the error in the orientation.
+
+    Args:
+        pos: The cartesian position. Shape is (N, 3).
+        rot: The quaternion in (w, x, y, z). Shape is (N, 4).
+
+    Returns:
+        True if all the input poses result in identity transform. Otherwise, False.
+    """
+    # create identity transformations
+    pos_identity = torch.zeros_like(pos)
+    rot_identity = torch.zeros_like(rot)
+    rot_identity[..., 0] = 1
+    # compare input to identity
+    return torch.allclose(pos, pos_identity) and torch.allclose(rot, rot_identity)
+
+
+@torch.jit.script
+def combine_frame_transforms(
+    t01: torch.Tensor, q01: torch.Tensor, t12: torch.Tensor | None = None, q12: torch.Tensor | None = None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""Combine transformations between two reference frames into a stationary frame.
+
+    It performs the following transformation operation: :math:`T_{02} = T_{01} \times T_{12}`,
+    where :math:`T_{AB}` is the homogeneous transformation matrix from frame A to B.
+
+    Args:
+        t01: Position of frame 1 w.r.t. frame 0. Shape is (N, 3).
+        q01: Quaternion orientation of frame 1 w.r.t. frame 0 in (w, x, y, z). Shape is (N, 4).
+        t12: Position of frame 2 w.r.t. frame 1. Shape is (N, 3).
+            Defaults to None, in which case the position is assumed to be zero.
+        q12: Quaternion orientation of frame 2 w.r.t. frame 1 in (w, x, y, z). Shape is (N, 4).
+            Defaults to None, in which case the orientation is assumed to be identity.
+
+    Returns:
+        A tuple containing the position and orientation of frame 2 w.r.t. frame 0.
+        Shape of the tensors are (N, 3) and (N, 4) respectively.
+    """
+    # compute orientation
+    if q12 is not None:
+        q02 = quat_mul(q01, q12)
+    else:
+        q02 = q01
+    # compute translation
+    if t12 is not None:
+        t02 = t01 + quat_apply(q01, t12)
+    else:
+        t02 = t01
+
+    return t02, q02
+
+
+def rigid_body_twist_transform(
+    v0: torch.Tensor, w0: torch.Tensor, t01: torch.Tensor, q01: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""Transform the linear and angular velocity of a rigid body between reference frames.
+
+    Given the twist of 0 relative to frame 0, this function computes the twist of 1 relative to frame 1
+    from the position and orientation of frame 1 relative to frame 0. The transformation follows the
+    equations:
+
+    .. math::
+
+        w_11 = R_{10} w_00 = R_{01}^{-1} w_00
+        v_11 = R_{10} v_00 + R_{10} (w_00 \times t_01) = R_{01}^{-1} (v_00 + (w_00 \times t_01))
+
+    where
+
+        - :math:`R_{01}` is the rotation matrix from frame 0 to frame 1 derived from quaternion :math:`q_{01}`.
+        - :math:`t_{01}` is the position of frame 1 relative to frame 0 expressed in frame 0
+        - :math:`w_0` is the angular velocity of 0 in frame 0
+        - :math:`v_0` is the linear velocity of 0 in frame 0
+
+    Args:
+        v0: Linear velocity of 0 in frame 0. Shape is (N, 3).
+        w0: Angular velocity of 0 in frame 0. Shape is (N, 3).
+        t01: Position of frame 1 w.r.t. frame 0. Shape is (N, 3).
+        q01: Quaternion orientation of frame 1 w.r.t. frame 0 in (w, x, y, z). Shape is (N, 4).
+
+    Returns:
+        A tuple containing:
+        - The transformed linear velocity in frame 1. Shape is (N, 3).
+        - The transformed angular velocity in frame 1. Shape is (N, 3).
+    """
+    w1 = quat_rotate_inverse(q01, w0)
+    v1 = quat_rotate_inverse(q01, v0 + torch.cross(w0, t01, dim=-1))
+    return v1, w1
+
+
+# @torch.jit.script
+def subtract_frame_transforms(
+    t01: torch.Tensor, q01: torch.Tensor, t02: torch.Tensor | None = None, q02: torch.Tensor | None = None
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""Subtract transformations between two reference frames into a stationary frame.
+
+    It performs the following transformation operation: :math:`T_{12} = T_{01}^{-1} \times T_{02}`,
+    where :math:`T_{AB}` is the homogeneous transformation matrix from frame A to B.
+
+    Args:
+        t01: Position of frame 1 w.r.t. frame 0. Shape is (N, 3).
+        q01: Quaternion orientation of frame 1 w.r.t. frame 0 in (w, x, y, z). Shape is (N, 4).
+        t02: Position of frame 2 w.r.t. frame 0. Shape is (N, 3).
+            Defaults to None, in which case the position is assumed to be zero.
+        q02: Quaternion orientation of frame 2 w.r.t. frame 0 in (w, x, y, z). Shape is (N, 4).
+            Defaults to None, in which case the orientation is assumed to be identity.
+
+    Returns:
+        A tuple containing the position and orientation of frame 2 w.r.t. frame 1.
+        Shape of the tensors are (N, 3) and (N, 4) respectively.
+    """
+    # compute orientation
+    q10 = quat_inv(q01)
+    if q02 is not None:
+        q12 = quat_mul(q10, q02)
+    else:
+        q12 = q10
+    # compute translation
+    if t02 is not None:
+        t12 = quat_apply(q10, t02 - t01)
+    else:
+        t12 = quat_apply(q10, -t01)
+    return t12, q12
+
+
+# @torch.jit.script
+def compute_pose_error(
+    t01: torch.Tensor,
+    q01: torch.Tensor,
+    t02: torch.Tensor,
+    q02: torch.Tensor,
+    rot_error_type: Literal["quat", "axis_angle"] = "axis_angle",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute the position and orientation error between source and target frames.
+
+    Args:
+        t01: Position of source frame. Shape is (N, 3).
+        q01: Quaternion orientation of source frame in (w, x, y, z). Shape is (N, 4).
+        t02: Position of target frame. Shape is (N, 3).
+        q02: Quaternion orientation of target frame in (w, x, y, z). Shape is (N, 4).
+        rot_error_type: The rotation error type to return: "quat", "axis_angle".
+            Defaults to "axis_angle".
+
+    Returns:
+        A tuple containing position and orientation error. Shape of position error is (N, 3).
+        Shape of orientation error depends on the value of :attr:`rot_error_type`:
+
+        - If :attr:`rot_error_type` is "quat", the orientation error is returned
+          as a quaternion. Shape is (N, 4).
+        - If :attr:`rot_error_type` is "axis_angle", the orientation error is
+          returned as an axis-angle vector. Shape is (N, 3).
+
+    Raises:
+        ValueError: Invalid rotation error type.
+    """
+    # Compute quaternion error (i.e., difference quaternion)
+    # Reference: https://personal.utdallas.edu/~sxb027100/dock/quaternion.html
+    # q_current_norm = q_current * q_current_conj
+    source_quat_norm = quat_mul(q01, quat_conjugate(q01))[:, 0]
+    # q_current_inv = q_current_conj / q_current_norm
+    source_quat_inv = quat_conjugate(q01) / source_quat_norm.unsqueeze(-1)
+    # q_error = q_target * q_current_inv
+    quat_error = quat_mul(q02, source_quat_inv)
+
+    # Compute position error
+    pos_error = t02 - t01
+
+    # return error based on specified type
+    if rot_error_type == "quat":
+        return pos_error, quat_error
+    elif rot_error_type == "axis_angle":
+        # Convert to axis-angle error
+        axis_angle_error = axis_angle_from_quat(quat_error)
+        return pos_error, axis_angle_error
+    else:
+        raise ValueError(f"Unsupported orientation error type: {rot_error_type}. Valid: 'quat', 'axis_angle'.")
+
+
+@torch.jit.script
+def apply_delta_pose(
+    source_pos: torch.Tensor, source_rot: torch.Tensor, delta_pose: torch.Tensor, eps: float = 1.0e-6
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Applies delta pose transformation on source pose.
+
+    The first three elements of `delta_pose` are interpreted as cartesian position displacement.
+    The remaining three elements of `delta_pose` are interpreted as orientation displacement
+    in the angle-axis format.
+
+    Args:
+        source_pos: Position of source frame. Shape is (N, 3).
+        source_rot: Quaternion orientation of source frame in (w, x, y, z). Shape is (N, 4)..
+        delta_pose: Position and orientation displacements. Shape is (N, 6).
+        eps: The tolerance to consider orientation displacement as zero. Defaults to 1.0e-6.
+
+    Returns:
+        A tuple containing the displaced position and orientation frames.
+        Shape of the tensors are (N, 3) and (N, 4) respectively.
+    """
+    # number of poses given
+    num_poses = source_pos.shape[0]
+    device = source_pos.device
+
+    # interpret delta_pose[:, 0:3] as target position displacements
+    target_pos = source_pos + delta_pose[:, 0:3]
+    # interpret delta_pose[:, 3:6] as target rotation displacements
+    rot_actions = delta_pose[:, 3:6]
+    angle = torch.linalg.vector_norm(rot_actions, dim=1)
+    axis = rot_actions / angle.unsqueeze(-1)
+    # change from axis-angle to quat convention
+    identity_quat = torch.tensor([1.0, 0.0, 0.0, 0.0], device=device).repeat(num_poses, 1)
+    rot_delta_quat = torch.where(
+        angle.unsqueeze(-1).repeat(1, 4) > eps, quat_from_angle_axis(angle, axis), identity_quat
+    )
+    # TODO: Check if this is the correct order for this multiplication.
+    target_rot = quat_mul(rot_delta_quat, source_rot)
+
+    return target_pos, target_rot
+
+
+# @torch.jit.script
+def transform_points(
+    points: torch.Tensor, pos: torch.Tensor | None = None, quat: torch.Tensor | None = None
+) -> torch.Tensor:
+    r"""Transform input points in a given frame to a target frame.
+
+    This function transform points from a source frame to a target frame. The transformation is defined by the
+    position :math:`t` and orientation :math:`R` of the target frame in the source frame.
+
+    .. math::
+        p_{target} = R_{target} \times p_{source} + t_{target}
+
+    If the input `points` is a batch of points, the inputs `pos` and `quat` must be either a batch of
+    positions and quaternions or a single position and quaternion. If the inputs `pos` and `quat` are
+    a single position and quaternion, the same transformation is applied to all points in the batch.
+
+    If either the inputs :attr:`pos` and :attr:`quat` are None, the corresponding transformation is not applied.
+
+    Args:
+        points: Points to transform. Shape is (N, P, 3) or (P, 3).
+        pos: Position of the target frame. Shape is (N, 3) or (3,).
+            Defaults to None, in which case the position is assumed to be zero.
+        quat: Quaternion orientation of the target frame in (w, x, y, z). Shape is (N, 4) or (4,).
+            Defaults to None, in which case the orientation is assumed to be identity.
+
+    Returns:
+        Transformed points in the target frame. Shape is (N, P, 3) or (P, 3).
+
+    Raises:
+        ValueError: If the inputs `points` is not of shape (N, P, 3) or (P, 3).
+        ValueError: If the inputs `pos` is not of shape (N, 3) or (3,).
+        ValueError: If the inputs `quat` is not of shape (N, 4) or (4,).
+    """
+    points_batch = points.clone()
+    # check if inputs are batched
+    is_batched = points_batch.dim() == 3
+    # -- check inputs
+    if points_batch.dim() == 2:
+        points_batch = points_batch[None]  # (P, 3) -> (1, P, 3)
+    if points_batch.dim() != 3:
+        raise ValueError(f"Expected points to have dim = 2 or dim = 3: got shape {points.shape}")
+    if not (pos is None or pos.dim() == 1 or pos.dim() == 2):
+        raise ValueError(f"Expected pos to have dim = 1 or dim = 2: got shape {pos.shape}")
+    if not (quat is None or quat.dim() == 1 or quat.dim() == 2):
+        raise ValueError(f"Expected quat to have dim = 1 or dim = 2: got shape {quat.shape}")
+    # -- rotation
+    if quat is not None:
+        # convert to batched rotation matrix
+        rot_mat = matrix_from_quat(quat)
+        if rot_mat.dim() == 2:
+            rot_mat = rot_mat[None]  # (3, 3) -> (1, 3, 3)
+        # convert points to matching batch size (N, P, 3) -> (N, 3, P)
+        # and apply rotation
+        points_batch = torch.matmul(rot_mat, points_batch.transpose_(1, 2))
+        # (N, 3, P) -> (N, P, 3)
+        points_batch = points_batch.transpose_(1, 2)
+    # -- translation
+    if pos is not None:
+        # convert to batched translation vector
+        if pos.dim() == 1:
+            pos = pos[None, None, :]  # (3,) -> (1, 1, 3)
+        else:
+            pos = pos[:, None, :]  # (N, 3) -> (N, 1, 3)
+        # apply translation
+        points_batch += pos
+    # -- return points in same shape as input
+    if not is_batched:
+        points_batch = points_batch.squeeze(0)  # (1, P, 3) -> (P, 3)
+
+    return points_batch
+
+
+"""
+Projection operations.
+"""
+
+
+@torch.jit.script
+def orthogonalize_perspective_depth(depth: torch.Tensor, intrinsics: torch.Tensor) -> torch.Tensor:
+    """Converts perspective depth image to orthogonal depth image.
+
+    Perspective depth images contain distances measured from the camera's optical center.
+    Meanwhile, orthogonal depth images provide the distance from the camera's image plane.
+    This method uses the camera geometry to convert perspective depth to orthogonal depth image.
+
+    The function assumes that the width and height are both greater than 1.
+
+    Args:
+        depth: The perspective depth images. Shape is (H, W) or or (H, W, 1) or (N, H, W) or (N, H, W, 1).
+        intrinsics: The camera's calibration matrix. If a single matrix is provided, the same
+            calibration matrix is used across all the depth images in the batch.
+            Shape is (3, 3) or (N, 3, 3).
+
+    Returns:
+        The orthogonal depth images. Shape matches the input shape of depth images.
+
+    Raises:
+        ValueError: When depth is not of shape (H, W) or (H, W, 1) or (N, H, W) or (N, H, W, 1).
+        ValueError: When intrinsics is not of shape (3, 3) or (N, 3, 3).
+    """
+    # Clone inputs to avoid in-place modifications
+    perspective_depth_batch = depth.clone()
+    intrinsics_batch = intrinsics.clone()
+
+    # Check if inputs are batched
+    is_batched = perspective_depth_batch.dim() == 4 or (
+        perspective_depth_batch.dim() == 3 and perspective_depth_batch.shape[-1] != 1
+    )
+
+    # Track whether the last dimension was singleton
+    add_last_dim = False
+    if perspective_depth_batch.dim() == 4 and perspective_depth_batch.shape[-1] == 1:
+        add_last_dim = True
+        perspective_depth_batch = perspective_depth_batch.squeeze(dim=3)  # (N, H, W, 1) -> (N, H, W)
+    if perspective_depth_batch.dim() == 3 and perspective_depth_batch.shape[-1] == 1:
+        add_last_dim = True
+        perspective_depth_batch = perspective_depth_batch.squeeze(dim=2)  # (H, W, 1) -> (H, W)
+
+    if perspective_depth_batch.dim() == 2:
+        perspective_depth_batch = perspective_depth_batch[None]  # (H, W) -> (1, H, W)
+
+    if intrinsics_batch.dim() == 2:
+        intrinsics_batch = intrinsics_batch[None]  # (3, 3) -> (1, 3, 3)
+
+    if is_batched and intrinsics_batch.shape[0] == 1:
+        intrinsics_batch = intrinsics_batch.expand(perspective_depth_batch.shape[0], -1, -1)  # (1, 3, 3) -> (N, 3, 3)
+
+    # Validate input shapes
+    if perspective_depth_batch.dim() != 3:
+        raise ValueError(f"Expected depth images to have 2, 3, or 4 dimensions; got {depth.shape}.")
+    if intrinsics_batch.dim() != 3:
+        raise ValueError(f"Expected intrinsics to have shape (3, 3) or (N, 3, 3); got {intrinsics.shape}.")
+
+    # Image dimensions
+    im_height, im_width = perspective_depth_batch.shape[1:]
+
+    # Get the intrinsics parameters
+    fx = intrinsics_batch[:, 0, 0].view(-1, 1, 1)
+    fy = intrinsics_batch[:, 1, 1].view(-1, 1, 1)
+    cx = intrinsics_batch[:, 0, 2].view(-1, 1, 1)
+    cy = intrinsics_batch[:, 1, 2].view(-1, 1, 1)
+
+    # Create meshgrid of pixel coordinates
+    u_grid = torch.arange(im_width, device=depth.device, dtype=depth.dtype)
+    v_grid = torch.arange(im_height, device=depth.device, dtype=depth.dtype)
+    u_grid, v_grid = torch.meshgrid(u_grid, v_grid, indexing="xy")
+
+    # Expand the grids for batch processing
+    u_grid = u_grid.unsqueeze(0).expand(perspective_depth_batch.shape[0], -1, -1)
+    v_grid = v_grid.unsqueeze(0).expand(perspective_depth_batch.shape[0], -1, -1)
+
+    # Compute the squared terms for efficiency
+    x_term = ((u_grid - cx) / fx) ** 2
+    y_term = ((v_grid - cy) / fy) ** 2
+
+    # Calculate the orthogonal (normal) depth
+    orthogonal_depth = perspective_depth_batch / torch.sqrt(1 + x_term + y_term)
+
+    # Restore the last dimension if it was present in the input
+    if add_last_dim:
+        orthogonal_depth = orthogonal_depth.unsqueeze(-1)
+
+    # Return to original shape if input was not batched
+    if not is_batched:
+        orthogonal_depth = orthogonal_depth.squeeze(0)
+
+    return orthogonal_depth
+
+
+@torch.jit.script
+def unproject_depth(depth: torch.Tensor, intrinsics: torch.Tensor, is_ortho: bool = True) -> torch.Tensor:
+    r"""Un-project depth image into a pointcloud.
+
+    This function converts orthogonal or perspective depth images into points given the calibration matrix
+    of the camera. It uses the following transformation based on camera geometry:
+
+    .. math::
+        p_{3D} = K^{-1} \times [u, v, 1]^T \times d
+
+    where :math:`p_{3D}` is the 3D point, :math:`d` is the depth value (measured from the image plane),
+    :math:`u` and :math:`v` are the pixel coordinates and :math:`K` is the intrinsic matrix.
+
+    The function assumes that the width and height are both greater than 1. This makes the function
+    deal with many possible shapes of depth images and intrinsics matrices.
+
+    .. note::
+        If :attr:`is_ortho` is False, the input depth images are transformed to orthogonal depth images
+        by using the :meth:`orthogonalize_perspective_depth` method.
+
+    Args:
+        depth: The depth measurement. Shape is (H, W) or or (H, W, 1) or (N, H, W) or (N, H, W, 1).
+        intrinsics: The camera's calibration matrix. If a single matrix is provided, the same
+            calibration matrix is used across all the depth images in the batch.
+            Shape is (3, 3) or (N, 3, 3).
+        is_ortho: Whether the input depth image is orthogonal or perspective depth image. If True, the input
+            depth image is considered as the *orthogonal* type, where the measurements are from the camera's
+            image plane. If False, the depth image is considered as the *perspective* type, where the
+            measurements are from the camera's optical center. Defaults to True.
+
+    Returns:
+        The 3D coordinates of points. Shape is (P, 3) or (N, P, 3).
+
+    Raises:
+        ValueError: When depth is not of shape (H, W) or (H, W, 1) or (N, H, W) or (N, H, W, 1).
+        ValueError: When intrinsics is not of shape (3, 3) or (N, 3, 3).
+    """
+    # clone inputs to avoid in-place modifications
+    intrinsics_batch = intrinsics.clone()
+    # convert depth image to orthogonal if needed
+    if not is_ortho:
+        depth_batch = orthogonalize_perspective_depth(depth, intrinsics)
+    else:
+        depth_batch = depth.clone()
+
+    # check if inputs are batched
+    is_batched = depth_batch.dim() == 4 or (depth_batch.dim() == 3 and depth_batch.shape[-1] != 1)
+    # make sure inputs are batched
+    if depth_batch.dim() == 3 and depth_batch.shape[-1] == 1:
+        depth_batch = depth_batch.squeeze(dim=2)  # (H, W, 1) -> (H, W)
+    if depth_batch.dim() == 2:
+        depth_batch = depth_batch[None]  # (H, W) -> (1, H, W)
+    if depth_batch.dim() == 4 and depth_batch.shape[-1] == 1:
+        depth_batch = depth_batch.squeeze(dim=3)  # (N, H, W, 1) -> (N, H, W)
+    if intrinsics_batch.dim() == 2:
+        intrinsics_batch = intrinsics_batch[None]  # (3, 3) -> (1, 3, 3)
+    # check shape of inputs
+    if depth_batch.dim() != 3:
+        raise ValueError(f"Expected depth images to have dim = 2 or 3 or 4: got shape {depth.shape}")
+    if intrinsics_batch.dim() != 3:
+        raise ValueError(f"Expected intrinsics to have shape (3, 3) or (N, 3, 3): got shape {intrinsics.shape}")
+
+    # get image height and width
+    im_height, im_width = depth_batch.shape[1:]
+    # create image points in homogeneous coordinates (3, H x W)
+    indices_u = torch.arange(im_width, device=depth.device, dtype=depth.dtype)
+    indices_v = torch.arange(im_height, device=depth.device, dtype=depth.dtype)
+    img_indices = torch.stack(torch.meshgrid([indices_u, indices_v], indexing="ij"), dim=0).reshape(2, -1)
+    pixels = torch.nn.functional.pad(img_indices, (0, 0, 0, 1), mode="constant", value=1.0)
+    pixels = pixels.unsqueeze(0)  # (3, H x W) -> (1, 3, H x W)
+
+    # unproject points into 3D space
+    points = torch.matmul(torch.inverse(intrinsics_batch), pixels)  # (N, 3, H x W)
+    points = points / points[:, -1, :].unsqueeze(1)  # normalize by last coordinate
+    # flatten depth image (N, H, W) -> (N, H x W)
+    depth_batch = depth_batch.transpose_(1, 2).reshape(depth_batch.shape[0], -1).unsqueeze(2)
+    depth_batch = depth_batch.expand(-1, -1, 3)
+    # scale points by depth
+    points_xyz = points.transpose_(1, 2) * depth_batch  # (N, H x W, 3)
+
+    # return points in same shape as input
+    if not is_batched:
+        points_xyz = points_xyz.squeeze(0)
+
+    return points_xyz
+
+
+@torch.jit.script
+def project_points(points: torch.Tensor, intrinsics: torch.Tensor) -> torch.Tensor:
+    r"""Projects 3D points into 2D image plane.
+
+    This project 3D points into a 2D image plane. The transformation is defined by the intrinsic
+    matrix of the camera.
+
+    .. math::
+
+        \begin{align}
+            p &= K \times p_{3D}  = \\
+            p_{2D} &= \begin{pmatrix} u \\ v \\  d \end{pmatrix}
+                    = \begin{pmatrix} p[0] / p[2] \\  p[1] / p[2] \\ Z \end{pmatrix}
+        \end{align}
+
+    where :math:`p_{2D} = (u, v, d)` is the projected 3D point, :math:`p_{3D} = (X, Y, Z)` is the
+    3D point and :math:`K \in \mathbb{R}^{3 \times 3}` is the intrinsic matrix.
+
+    If `points` is a batch of 3D points and `intrinsics` is a single intrinsic matrix, the same
+    calibration matrix is applied to all points in the batch.
+
+    Args:
+        points: The 3D coordinates of points. Shape is (P, 3) or (N, P, 3).
+        intrinsics: Camera's calibration matrix. Shape is (3, 3) or (N, 3, 3).
+
+    Returns:
+        Projected 3D coordinates of points. Shape is (P, 3) or (N, P, 3).
+    """
+    # clone the inputs to avoid in-place operations modifying the original data
+    points_batch = points.clone()
+    intrinsics_batch = intrinsics.clone()
+
+    # check if inputs are batched
+    is_batched = points_batch.dim() == 2
+    # make sure inputs are batched
+    if points_batch.dim() == 2:
+        points_batch = points_batch[None]  # (P, 3) -> (1, P, 3)
+    if intrinsics_batch.dim() == 2:
+        intrinsics_batch = intrinsics_batch[None]  # (3, 3) -> (1, 3, 3)
+    # check shape of inputs
+    if points_batch.dim() != 3:
+        raise ValueError(f"Expected points to have dim = 3: got shape {points.shape}.")
+    if intrinsics_batch.dim() != 3:
+        raise ValueError(f"Expected intrinsics to have shape (3, 3) or (N, 3, 3): got shape {intrinsics.shape}.")
+
+    # project points into 2D image plane
+    points_2d = torch.matmul(intrinsics_batch, points_batch.transpose(1, 2))
+    points_2d = points_2d / points_2d[:, -1, :].unsqueeze(1)  # normalize by last coordinate
+    points_2d = points_2d.transpose_(1, 2)  # (N, 3, P) -> (N, P, 3)
+    # replace last coordinate with depth
+    points_2d[:, :, -1] = points_batch[:, :, -1]
+
+    # return points in same shape as input
+    if not is_batched:
+        points_2d = points_2d.squeeze(0)  # (1, 3, P) -> (3, P)
+
+    return points_2d
+
+
+"""
+Sampling
+"""
+
+
+@torch.jit.script
+def default_orientation(num: int, device: str) -> torch.Tensor:
+    """Returns identity rotation transform.
+
+    Args:
+        num: The number of rotations to sample.
+        device: Device to create tensor on.
+
+    Returns:
+        Identity quaternion in (w, x, y, z). Shape is (num, 4).
+    """
+    quat = torch.zeros((num, 4), dtype=torch.float, device=device)
+    quat[..., 0] = 1.0
+
+    return quat
+
+
+@torch.jit.script
+def random_orientation(num: int, device: str) -> torch.Tensor:
+    """Returns sampled rotation in 3D as quaternion.
+
+    Args:
+        num: The number of rotations to sample.
+        device: Device to create tensor on.
+
+    Returns:
+        Sampled quaternion in (w, x, y, z). Shape is (num, 4).
+
+    Reference:
+        https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.transform.Rotation.random.html
+    """
+    # sample random orientation from normal distribution
+    quat = torch.randn((num, 4), dtype=torch.float, device=device)
+    # normalize the quaternion
+    return torch.nn.functional.normalize(quat, p=2.0, dim=-1, eps=1e-12)
+
+
+@torch.jit.script
+def random_yaw_orientation(num: int, device: str) -> torch.Tensor:
+    """Returns sampled rotation around z-axis.
+
+    Args:
+        num: The number of rotations to sample.
+        device: Device to create tensor on.
+
+    Returns:
+        Sampled quaternion in (w, x, y, z). Shape is (num, 4).
+    """
+    roll = torch.zeros(num, dtype=torch.float, device=device)
+    pitch = torch.zeros(num, dtype=torch.float, device=device)
+    yaw = 2 * torch.pi * torch.rand(num, dtype=torch.float, device=device)
+
+    return quat_from_euler_xyz(roll, pitch, yaw)
+
+
+def sample_triangle(lower: float, upper: float, size: int | tuple[int, ...], device: str) -> torch.Tensor:
+    """Randomly samples tensor from a triangular distribution.
+
+    Args:
+        lower: The lower range of the sampled tensor.
+        upper: The upper range of the sampled tensor.
+        size: The shape of the tensor.
+        device: Device to create tensor on.
+
+    Returns:
+        Sampled tensor. Shape is based on :attr:`size`.
+    """
+    # convert to tuple
+    if isinstance(size, int):
+        size = (size,)
+    # create random tensor in the range [-1, 1]
+    r = 2 * torch.rand(*size, device=device) - 1
+    # convert to triangular distribution
+    r = torch.where(r < 0.0, -torch.sqrt(-r), torch.sqrt(r))
+    # rescale back to [0, 1]
+    r = (r + 1.0) / 2.0
+    # rescale to range [lower, upper]
+    return (upper - lower) * r + lower
+
+
+def sample_uniform(
+    lower: torch.Tensor | float, upper: torch.Tensor | float, size: int | tuple[int, ...], device: str
+) -> torch.Tensor:
+    """Sample uniformly within a range.
+
+    Args:
+        lower: Lower bound of uniform range.
+        upper: Upper bound of uniform range.
+        size: The shape of the tensor.
+        device: Device to create tensor on.
+
+    Returns:
+        Sampled tensor. Shape is based on :attr:`size`.
+    """
+    # convert to tuple
+    if isinstance(size, int):
+        size = (size,)
+    # return tensor
+    return torch.rand(*size, device=device) * (upper - lower) + lower
+
+
+def sample_log_uniform(
+    lower: torch.Tensor | float, upper: torch.Tensor | float, size: int | tuple[int, ...], device: str
+) -> torch.Tensor:
+    r"""Sample using log-uniform distribution within a range.
+
+    The log-uniform distribution is defined as a uniform distribution in the log-space. It
+    is useful for sampling values that span several orders of magnitude. The sampled values
+    are uniformly distributed in the log-space and then exponentiated to get the final values.
+
+    .. math::
+
+        x = \exp(\text{uniform}(\log(\text{lower}), \log(\text{upper})))
+
+    Args:
+        lower: Lower bound of uniform range.
+        upper: Upper bound of uniform range.
+        size: The shape of the tensor.
+        device: Device to create tensor on.
+
+    Returns:
+        Sampled tensor. Shape is based on :attr:`size`.
+    """
+    # cast to tensor if not already
+    if not isinstance(lower, torch.Tensor):
+        lower = torch.tensor(lower, dtype=torch.float, device=device)
+    if not isinstance(upper, torch.Tensor):
+        upper = torch.tensor(upper, dtype=torch.float, device=device)
+    # sample in log-space and exponentiate
+    return torch.exp(sample_uniform(torch.log(lower), torch.log(upper), size, device))
+
+
+def sample_gaussian(
+    mean: torch.Tensor | float, std: torch.Tensor | float, size: int | tuple[int, ...], device: str
+) -> torch.Tensor:
+    """Sample using gaussian distribution.
+
+    Args:
+        mean: Mean of the gaussian.
+        std: Std of the gaussian.
+        size: The shape of the tensor.
+        device: Device to create tensor on.
+
+    Returns:
+        Sampled tensor.
+    """
+    if isinstance(mean, float):
+        if isinstance(size, int):
+            size = (size,)
+        return torch.normal(mean=mean, std=std, size=size).to(device=device)
+    else:
+        return torch.normal(mean=mean, std=std).to(device=device)
+
+
+def sample_cylinder(
+    radius: float, h_range: tuple[float, float], size: int | tuple[int, ...], device: str
+) -> torch.Tensor:
+    """Sample 3D points uniformly on a cylinder's surface.
+
+    The cylinder is centered at the origin and aligned with the z-axis. The height of the cylinder is
+    sampled uniformly from the range :obj:`h_range`, while the radius is fixed to :obj:`radius`.
+
+    The sampled points are returned as a tensor of shape :obj:`(*size, 3)`, i.e. the last dimension
+    contains the x, y, and z coordinates of the sampled points.
+
+    Args:
+        radius: The radius of the cylinder.
+        h_range: The minimum and maximum height of the cylinder.
+        size: The shape of the tensor.
+        device: Device to create tensor on.
+
+    Returns:
+        Sampled tensor. Shape is :obj:`(*size, 3)`.
+    """
+    # sample angles
+    angles = (torch.rand(size, device=device) * 2 - 1) * torch.pi
+    h_min, h_max = h_range
+    # add shape
+    if isinstance(size, int):
+        size = (size, 3)
+    else:
+        size += (3,)
+    # allocate a tensor
+    xyz = torch.zeros(size, device=device)
+    xyz[..., 0] = radius * torch.cos(angles)
+    xyz[..., 1] = radius * torch.sin(angles)
+    xyz[..., 2].uniform_(h_min, h_max)
+    # return positions
+    return xyz
+
+
+"""
+Orientation Conversions
+"""
+
+
+def convert_camera_frame_orientation_convention(
+    orientation: torch.Tensor,
+    origin: Literal["opengl", "ros", "world"] = "opengl",
+    target: Literal["opengl", "ros", "world"] = "ros",
+) -> torch.Tensor:
+    r"""Converts a quaternion representing a rotation from one convention to another.
+
+    In USD, the camera follows the ``"opengl"`` convention. Thus, it is always in **Y up** convention.
+    This means that the camera is looking down the -Z axis with the +Y axis pointing up , and +X axis pointing right.
+    However, in ROS, the camera is looking down the +Z axis with the +Y axis pointing down, and +X axis pointing right.
+    Thus, the camera needs to be rotated by :math:`180^{\circ}` around the X axis to follow the ROS convention.
+
+    .. math::
+
+        T_{ROS} = \begin{bmatrix} 1 & 0 & 0 & 0 \\ 0 & -1 & 0 & 0 \\ 0 & 0 & -1 & 0 \\ 0 & 0 & 0 & 1 \end{bmatrix} T_{USD}
+
+    On the other hand, the typical world coordinate system is with +X pointing forward, +Y pointing left,
+    and +Z pointing up. The camera can also be set in this convention by rotating the camera by :math:`90^{\circ}`
+    around the X axis and :math:`-90^{\circ}` around the Y axis.
+
+    .. math::
+
+        T_{WORLD} = \begin{bmatrix} 0 & 0 & -1 & 0 \\ -1 & 0 & 0 & 0 \\ 0 & 1 & 0 & 0 \\ 0 & 0 & 0 & 1 \end{bmatrix} T_{USD}
+
+    Thus, based on their application, cameras follow different conventions for their orientation. This function
+    converts a quaternion from one convention to another.
+
+    Possible conventions are:
+
+    - :obj:`"opengl"` - forward axis: -Z - up axis +Y - Offset is applied in the OpenGL (Usd.Camera) convention
+    - :obj:`"ros"`    - forward axis: +Z - up axis -Y - Offset is applied in the ROS convention
+    - :obj:`"world"`  - forward axis: +X - up axis +Z - Offset is applied in the World Frame convention
+
+    Args:
+        orientation: Quaternion of form `(w, x, y, z)` with shape (..., 4) in source convention.
+        origin: Convention to convert from. Defaults to "opengl".
+        target: Convention to convert to. Defaults to "ros".
+
+    Returns:
+        Quaternion of form `(w, x, y, z)` with shape (..., 4) in target convention
+    """
+    if target == origin:
+        return orientation.clone()
+
+    # -- unify input type
+    if origin == "ros":
+        # convert from ros to opengl convention
+        rotm = matrix_from_quat(orientation)
+        rotm[:, :, 2] = -rotm[:, :, 2]
+        rotm[:, :, 1] = -rotm[:, :, 1]
+        # convert to opengl convention
+        quat_gl = quat_from_matrix(rotm)
+    elif origin == "world":
+        # convert from world (x forward and z up) to opengl convention
+        rotm = matrix_from_quat(orientation)
+        rotm = torch.matmul(
+            rotm,
+            matrix_from_euler(torch.tensor([math.pi / 2, -math.pi / 2, 0], device=orientation.device), "XYZ"),
+        )
+        # convert to isaac-sim convention
+        quat_gl = quat_from_matrix(rotm)
+    else:
+        quat_gl = orientation
+
+    # -- convert to target convention
+    if target == "ros":
+        # convert from opengl to ros convention
+        rotm = matrix_from_quat(quat_gl)
+        rotm[:, :, 2] = -rotm[:, :, 2]
+        rotm[:, :, 1] = -rotm[:, :, 1]
+        return quat_from_matrix(rotm)
+    elif target == "world":
+        # convert from opengl to world (x forward and z up) convention
+        rotm = matrix_from_quat(quat_gl)
+        rotm = torch.matmul(
+            rotm,
+            matrix_from_euler(torch.tensor([math.pi / 2, -math.pi / 2, 0], device=orientation.device), "XYZ").T,
+        )
+        return quat_from_matrix(rotm)
+    else:
+        return quat_gl.clone()
+
+
+def create_rotation_matrix_from_view(
+    eyes: torch.Tensor,
+    targets: torch.Tensor,
+    up_axis: Literal["Y", "Z"] = "Z",
+    device: str = "cpu",
+) -> torch.Tensor:
+    """Compute the rotation matrix from world to view coordinates.
+
+    This function takes a vector ''eyes'' which specifies the location
+    of the camera in world coordinates and the vector ''targets'' which
+    indicate the position of the object.
+    The output is a rotation matrix representing the transformation
+    from world coordinates -> view coordinates.
+
+        The inputs eyes and targets can each be a
+        - 3 element tuple/list
+        - torch tensor of shape (1, 3)
+        - torch tensor of shape (N, 3)
+
+    Args:
+        eyes: Position of the camera in world coordinates.
+        targets: Position of the object in world coordinates.
+        up_axis: The up axis of the camera. Defaults to "Z".
+        device: The device to create torch tensors on. Defaults to "cpu".
+
+    The vectors are broadcast against each other so they all have shape (N, 3).
+
+    Returns:
+        R: (N, 3, 3) batched rotation matrices
+
+    Reference:
+    Based on PyTorch3D (https://github.com/facebookresearch/pytorch3d/blob/eaf0709d6af0025fe94d1ee7cec454bc3054826a/pytorch3d/renderer/cameras.py#L1635-L1685)
+    """
+    if up_axis == "Y":
+        up_axis_vec = torch.tensor((0, 1, 0), device=device, dtype=torch.float32).repeat(eyes.shape[0], 1)
+    elif up_axis == "Z":
+        up_axis_vec = torch.tensor((0, 0, 1), device=device, dtype=torch.float32).repeat(eyes.shape[0], 1)
+    else:
+        raise ValueError(f"Invalid up axis: {up_axis}. Valid options are 'Y' and 'Z'.")
+
+    # get rotation matrix in opengl format (-Z forward, +Y up)
+    z_axis = -torch.nn.functional.normalize(targets - eyes, eps=1e-5)
+    x_axis = torch.nn.functional.normalize(torch.cross(up_axis_vec, z_axis, dim=1), eps=1e-5)
+    y_axis = torch.nn.functional.normalize(torch.cross(z_axis, x_axis, dim=1), eps=1e-5)
+    is_close = torch.isclose(x_axis, torch.tensor(0.0), atol=5e-3).all(dim=1, keepdim=True)
+    if is_close.any():
+        replacement = torch.nn.functional.normalize(torch.cross(y_axis, z_axis, dim=1), eps=1e-5)
+        x_axis = torch.where(is_close, replacement, x_axis)
+    R = torch.cat((x_axis[:, None, :], y_axis[:, None, :], z_axis[:, None, :]), dim=1)
+    return R.transpose(1, 2)
+
+
+def make_pose(pos: torch.Tensor, rot: torch.Tensor) -> torch.Tensor:
+    """Creates transformation matrices from positions and rotation matrices.
+
+    Args:
+        pos: Batch of position vectors with last dimension of 3.
+        rot: Batch of rotation matrices with last 2 dimensions of (3, 3).
+
+    Returns:
+        Batch of pose matrices with last 2 dimensions of (4, 4).
+    """
+    assert isinstance(pos, torch.Tensor), "Input must be a torch tensor"
+    assert isinstance(rot, torch.Tensor), "Input must be a torch tensor"
+    assert pos.shape[:-1] == rot.shape[:-2]
+    assert pos.shape[-1] == rot.shape[-2] == rot.shape[-1] == 3
+    pose = torch.zeros(pos.shape[:-1] + (4, 4), dtype=pos.dtype, device=pos.device)
+    pose[..., :3, :3] = rot
+    pose[..., :3, 3] = pos
+    pose[..., 3, 3] = 1.0
+    return pose
+
+
+def unmake_pose(pose: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Splits transformation matrices into positions and rotation matrices.
+
+    Args:
+        pose: Batch of pose matrices with last 2 dimensions of (4, 4).
+
+    Returns:
+        Tuple containing:
+            - Batch of position vectors with last dimension of 3.
+            - Batch of rotation matrices with last 2 dimensions of (3, 3).
+    """
+    assert isinstance(pose, torch.Tensor), "Input must be a torch tensor"
+    return pose[..., :3, 3], pose[..., :3, :3]
+
+
+def pose_inv(pose: torch.Tensor) -> torch.Tensor:
+    """Computes the inverse of transformation matrices.
+
+    The inverse of a pose matrix [R t; 0 1] is [R.T -R.T*t; 0 1].
+
+    Args:
+        pose: Batch of pose matrices with last 2 dimensions of (4, 4).
+
+    Returns:
+        Batch of inverse pose matrices with last 2 dimensions of (4, 4).
+    """
+    assert isinstance(pose, torch.Tensor), "Input must be a torch tensor"
+    num_axes = len(pose.shape)
+    assert num_axes >= 2
+
+    inv_pose = torch.zeros_like(pose)
+
+    # Take transpose of last 2 dimensions
+    inv_pose[..., :3, :3] = pose[..., :3, :3].transpose(-1, -2)
+
+    # note: PyTorch matmul wants shapes [..., 3, 3] x [..., 3, 1] -> [..., 3, 1] so we add a dimension and take it away after
+    inv_pose[..., :3, 3] = torch.matmul(-inv_pose[..., :3, :3], pose[..., :3, 3:4])[..., 0]
+    inv_pose[..., 3, 3] = 1.0
+    return inv_pose
+
+
+def pose_in_A_to_pose_in_B(pose_in_A: torch.Tensor, pose_A_in_B: torch.Tensor) -> torch.Tensor:
+    """Converts poses from one coordinate frame to another.
+
+    Transforms matrices representing point C in frame A
+    to matrices representing the same point C in frame B.
+
+    Example usage:
+
+    frame_C_in_B = pose_in_A_to_pose_in_B(frame_C_in_A, frame_A_in_B)
+
+    Args:
+        pose_in_A: Batch of transformation matrices of point C in frame A.
+        pose_A_in_B: Batch of transformation matrices of frame A in frame B.
+
+    Returns:
+        Batch of transformation matrices of point C in frame B.
+    """
+    assert isinstance(pose_in_A, torch.Tensor), "Input must be a torch tensor"
+    assert isinstance(pose_A_in_B, torch.Tensor), "Input must be a torch tensor"
+    return torch.matmul(pose_A_in_B, pose_in_A)
+
+
+def quat_slerp(q1: torch.Tensor, q2: torch.Tensor, tau: float) -> torch.Tensor:
+    """Performs spherical linear interpolation (SLERP) between two quaternions.
+
+    This function does not support batch processing.
+
+    Args:
+        q1: First quaternion in (w, x, y, z) format.
+        q2: Second quaternion in (w, x, y, z) format.
+        tau: Interpolation coefficient between 0 (q1) and 1 (q2).
+
+    Returns:
+        Interpolated quaternion in (w, x, y, z) format.
+    """
+    assert isinstance(q1, torch.Tensor), "Input must be a torch tensor"
+    assert isinstance(q2, torch.Tensor), "Input must be a torch tensor"
+    if tau == 0.0:
+        return q1
+    elif tau == 1.0:
+        return q2
+    d = torch.dot(q1, q2)
+    if abs(abs(d) - 1.0) < torch.finfo(q1.dtype).eps * 4.0:
+        return q1
+    if d < 0.0:
+        # Invert rotation
+        d = -d
+        q2 *= -1.0
+    angle = torch.acos(torch.clamp(d, -1, 1))
+    if abs(angle) < torch.finfo(q1.dtype).eps * 4.0:
+        return q1
+    isin = 1.0 / torch.sin(angle)
+    q1 = q1 * torch.sin((1.0 - tau) * angle) * isin
+    q2 = q2 * torch.sin(tau * angle) * isin
+    q1 = q1 + q2
+    return q1
+
+
+def interpolate_rotations(R1: torch.Tensor, R2: torch.Tensor, num_steps: int, axis_angle: bool = True) -> torch.Tensor:
+    """Interpolates between two rotation matrices.
+
+    Args:
+        R1: First rotation matrix. (4x4).
+        R2: Second rotation matrix. (4x4).
+        num_steps: Number of desired interpolated rotations (excluding start and end).
+        axis_angle: If True, interpolate in axis-angle representation;
+                   otherwise use slerp. Defaults to True.
+
+    Returns:
+        Stack of interpolated rotation matrices of shape (num_steps + 1, 4, 4),
+        including the start and end rotations.
+    """
+    assert isinstance(R1, torch.Tensor), "Input must be a torch tensor"
+    assert isinstance(R2, torch.Tensor), "Input must be a torch tensor"
+    if axis_angle:
+        # Delta rotation expressed as axis-angle
+        delta_rot_mat = torch.matmul(R2, R1.transpose(-1, -2))
+        delta_quat = quat_from_matrix(delta_rot_mat)
+        delta_axis_angle = axis_angle_from_quat(delta_quat)
+
+        # Grab angle
+        delta_angle = torch.linalg.norm(delta_axis_angle)
+
+        # Fix the axis, and chunk the angle up into steps
+        rot_step_size = delta_angle / num_steps
+
+        # Convert into delta rotation matrices, and then convert to absolute rotations
+        if delta_angle < 0.05:
+            # Small angle - don't bother with interpolation
+            rot_steps = torch.stack([R2 for _ in range(num_steps)])
+        else:
+            # Make sure that axis is a unit vector
+            delta_axis = delta_axis_angle / delta_angle
+            delta_rot_steps = [
+                matrix_from_quat(quat_from_angle_axis(i * rot_step_size, delta_axis)) for i in range(num_steps)
+            ]
+            rot_steps = torch.stack([torch.matmul(delta_rot_steps[i], R1) for i in range(num_steps)])
+    else:
+        q1 = quat_from_matrix(R1)
+        q2 = quat_from_matrix(R2)
+        rot_steps = torch.stack(
+            [matrix_from_quat(quat_slerp(q1, q2, tau=float(i) / num_steps)) for i in range(num_steps)]
+        )
+
+    # Add in endpoint
+    rot_steps = torch.cat([rot_steps, R2[None]], dim=0)
+
+    return rot_steps
+
+
+def interpolate_poses(
+    pose_1: torch.Tensor,
+    pose_2: torch.Tensor,
+    num_steps: int = None,
+    step_size: float = None,
+    perturb: bool = False,
+) -> tuple[torch.Tensor, int]:
+    """Performs linear interpolation between two poses.
+
+    Args:
+        pose_1: 4x4 start pose.
+        pose_2: 4x4 end pose.
+        num_steps: If provided, specifies the number of desired interpolated points.
+                  Passing 0 corresponds to no interpolation. If None, step_size must be provided.
+        step_size: If provided, determines number of steps based on distance between poses.
+        perturb: If True, randomly perturbs interpolated position points.
+
+    Returns:
+        Tuple containing:
+            - Array of shape (N + 2, 4, 4) corresponding to the interpolated pose path.
+            - Number of interpolated points (N) in the path.
+    """
+    assert isinstance(pose_1, torch.Tensor), "Input must be a torch tensor"
+    assert isinstance(pose_2, torch.Tensor), "Input must be a torch tensor"
+    assert step_size is None or num_steps is None
+
+    pos1, rot1 = unmake_pose(pose_1)
+    pos2, rot2 = unmake_pose(pose_2)
+
+    if num_steps == 0:
+        # Skip interpolation
+        return (
+            torch.cat([pos1[None], pos2[None]], dim=0),
+            torch.cat([rot1[None], rot2[None]], dim=0),
+            num_steps,
+        )
+
+    delta_pos = pos2 - pos1
+    if num_steps is None:
+        assert torch.norm(delta_pos) > 0
+        num_steps = math.ceil(torch.norm(delta_pos) / step_size)
+
+    num_steps += 1  # Include starting pose
+    assert num_steps >= 2
+
+    # Linear interpolation of positions
+    pos_step_size = delta_pos / num_steps
+    grid = torch.arange(num_steps, dtype=torch.float32)
+    if perturb:
+        # Move interpolation grid points by up to half-size forward or backward
+        perturbations = torch.rand(num_steps - 2) - 0.5
+        grid[1:-1] += perturbations
+    pos_steps = torch.stack([pos1 + grid[i] * pos_step_size for i in range(num_steps)])
+
+    # Add in endpoint
+    pos_steps = torch.cat([pos_steps, pos2[None]], dim=0)
+
+    # Interpolate rotations
+    rot_steps = interpolate_rotations(R1=rot1, R2=rot2, num_steps=num_steps, axis_angle=True)
+
+    pose_steps = make_pose(pos_steps, rot_steps)
+    return pose_steps, num_steps - 1
+
+
+def transform_poses_from_frame_A_to_frame_B(
+    src_poses: torch.Tensor, frame_A: torch.Tensor, frame_B: torch.Tensor
+) -> torch.Tensor:
+    """Transforms poses from one coordinate frame to another preserving relative poses.
+
+    Args:
+        src_poses: Input pose sequence (shape [T, 4, 4]) from source demonstration.
+        frame_A: 4x4 frame A pose.
+        frame_B: 4x4 frame B pose.
+
+    Returns:
+        Transformed pose sequence of shape [T, 4, 4].
+    """
+    # Transform source end effector poses to be relative to source object frame
+    src_poses_rel_frame_B = pose_in_A_to_pose_in_B(
+        pose_in_A=src_poses,
+        pose_A_in_B=pose_inv(frame_B[None]),
+    )
+
+    # Apply relative poses to current object frame to obtain new target eef poses
+    transformed_poses = pose_in_A_to_pose_in_B(
+        pose_in_A=src_poses_rel_frame_B,
+        pose_A_in_B=frame_A[None],
+    )
+    return transformed_poses
+
+
+def generate_random_rotation(rot_boundary: float = (2 * math.pi)) -> torch.Tensor:
+    """Generates a random rotation matrix using Euler angles.
+
+    Args:
+        rot_boundary: Range for random rotation angles around each axis (x, y, z).
+
+    Returns:
+        3x3 rotation matrix.
+    """
+    angles = torch.rand(3) * rot_boundary
+    Rx = torch.tensor(
+        [[1, 0, 0], [0, torch.cos(angles[0]), -torch.sin(angles[0])], [0, torch.sin(angles[0]), torch.cos(angles[0])]]
+    )
+
+    Ry = torch.tensor(
+        [[torch.cos(angles[1]), 0, torch.sin(angles[1])], [0, 1, 0], [-torch.sin(angles[1]), 0, torch.cos(angles[1])]]
+    )
+
+    Rz = torch.tensor(
+        [[torch.cos(angles[2]), -torch.sin(angles[2]), 0], [torch.sin(angles[2]), torch.cos(angles[2]), 0], [0, 0, 1]]
+    )
+
+    # Combined rotation matrix
+    R = torch.matmul(torch.matmul(Rz, Ry), Rx)
+    return R
+
+
+def generate_random_translation(pos_boundary: float = 1) -> torch.Tensor:
+    """Generates a random translation vector.
+
+    Args:
+        pos_boundary: Range for random translation values in 3D space.
+
+    Returns:
+        3-element translation vector.
+    """
+    return torch.rand(3) * 2 * pos_boundary - pos_boundary  # Random translation in 3D space
+
+
+def generate_random_transformation_matrix(pos_boundary: float = 1, rot_boundary: float = (2 * math.pi)) -> torch.Tensor:
+    """Generates a random transformation matrix combining rotation and translation.
+
+    Args:
+        pos_boundary: Range for random translation values.
+        rot_boundary: Range for random rotation angles.
+
+    Returns:
+        4x4 transformation matrix.
+    """
+    R = generate_random_rotation(rot_boundary)
+    translation = generate_random_translation(pos_boundary)
+
+    # Create the transformation matrix
+    T = torch.eye(4)
+    T[:3, :3] = R
+    T[:3, 3] = translation
+
+    return T
+
+
+@torch.jit.script
+def transformation_matrix_from_dh(
+    d: torch.Tensor, theta: torch.Tensor, a: torch.Tensor, alpha: torch.Tensor
+) -> torch.Tensor:
+    """Compute transformation matrix from Denavit-Hartenberg parameters.
+    Args:
+        d: The link offset along the previous z to the common normal.
+        theta: The joint angle about the previous z, from the previous x to the common normal.
+        a: The link length along the common normal.
+        alpha: The link twist about the common normal, from the previous z to the current z.
+    Returns:
+        The transformation matrix. Shape is (*size, 4, 4).
+    """
+    # compute cosines and sines
+    cos_theta = torch.cos(theta)
+    sin_theta = torch.sin(theta)
+    cos_alpha = torch.cos(alpha)
+    sin_alpha = torch.sin(alpha)
+    zeros = torch.zeros_like(d, device=d.device)
+    ones = torch.ones_like(d, device=d.device)
+    # create transformation matrix
+    transformation_matrices = torch.stack(
+        [
+            torch.stack([cos_theta, -sin_theta, zeros, a], dim=-1),
+            torch.stack([sin_theta * cos_alpha, cos_theta * cos_alpha, -sin_alpha, -d * sin_alpha], dim=-1),
+            torch.stack([sin_theta * sin_alpha, cos_theta * sin_alpha, cos_alpha, d * cos_alpha], dim=-1),
+            torch.stack([zeros, zeros, zeros, ones], dim=-1),
+        ],
+        dim=-2,
+    )
+    transformation_matrix = torch.eye(4).repeat(d.shape[0], 1, 1).to(d.device)
+    for i in range(d.shape[1]):
+        transformation_matrix = torch.bmm(transformation_matrix, transformation_matrices[:, i])
+    return transformation_matrix

--- a/robotic_world_model/scripts/reinforcement_learning/rsl_rl/cli_args.py
+++ b/robotic_world_model/scripts/reinforcement_learning/rsl_rl/cli_args.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import argparse
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg
+
+
+def add_rsl_rl_args(parser: argparse.ArgumentParser):
+    """Add RSL-RL arguments to the parser.
+
+    Args:
+        parser: The parser to add the arguments to.
+    """
+    # create a new argument group
+    arg_group = parser.add_argument_group("rsl_rl", description="Arguments for RSL-RL agent.")
+    # -- experiment arguments
+    arg_group.add_argument(
+        "--experiment_name", type=str, default=None, help="Name of the experiment folder where logs will be stored."
+    )
+    arg_group.add_argument("--run_name", type=str, default=None, help="Run name suffix to the log directory.")
+    # -- load arguments
+    arg_group.add_argument("--resume", type=bool, default=None, help="Whether to resume from a checkpoint.")
+    arg_group.add_argument("--load_run", type=str, default=None, help="Name of the run folder to resume from.")
+    arg_group.add_argument("--checkpoint", type=str, default=None, help="Checkpoint file to resume from.")
+    # -- logger arguments
+    arg_group.add_argument(
+        "--logger", type=str, default=None, choices={"wandb", "tensorboard", "neptune"}, help="Logger module to use."
+    )
+    arg_group.add_argument(
+        "--log_project_name", type=str, default=None, help="Name of the logging project when using wandb or neptune."
+    )
+
+
+def parse_rsl_rl_cfg(task_name: str, args_cli: argparse.Namespace) -> RslRlOnPolicyRunnerCfg:
+    """Parse configuration for RSL-RL agent based on inputs.
+
+    Args:
+        task_name: The name of the environment.
+        args_cli: The command line arguments.
+
+    Returns:
+        The parsed configuration for RSL-RL agent based on inputs.
+    """
+    from isaaclab_tasks.utils.parse_cfg import load_cfg_from_registry
+
+    # load the default configuration
+    rslrl_cfg: RslRlOnPolicyRunnerCfg = load_cfg_from_registry(task_name, "rsl_rl_cfg_entry_point")
+    rslrl_cfg = update_rsl_rl_cfg(rslrl_cfg, args_cli)
+    return rslrl_cfg
+
+
+def update_rsl_rl_cfg(agent_cfg: RslRlOnPolicyRunnerCfg, args_cli: argparse.Namespace):
+    """Update configuration for RSL-RL agent based on inputs.
+
+    Args:
+        agent_cfg: The configuration for RSL-RL agent.
+        args_cli: The command line arguments.
+
+    Returns:
+        The updated configuration for RSL-RL agent based on inputs.
+    """
+    # override the default configuration with CLI arguments
+    if hasattr(args_cli, "seed") and args_cli.seed is not None:
+        agent_cfg.seed = args_cli.seed
+    if args_cli.device is not None:
+        agent_cfg.device = args_cli.device
+    if args_cli.resume is not None:
+        agent_cfg.resume = args_cli.resume
+    if args_cli.load_run is not None:
+        agent_cfg.load_run = args_cli.load_run
+    if args_cli.checkpoint is not None:
+        agent_cfg.load_checkpoint = args_cli.checkpoint
+    if args_cli.run_name is not None:
+        agent_cfg.run_name = args_cli.run_name
+    if args_cli.logger is not None:
+        agent_cfg.logger = args_cli.logger
+    # set the project name for wandb and neptune
+    if agent_cfg.logger in {"wandb", "neptune"} and args_cli.log_project_name:
+        agent_cfg.wandb_project = args_cli.log_project_name
+        agent_cfg.neptune_project = args_cli.log_project_name
+
+    return agent_cfg

--- a/robotic_world_model/scripts/reinforcement_learning/rsl_rl/play.py
+++ b/robotic_world_model/scripts/reinforcement_learning/rsl_rl/play.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Script to play a checkpoint if an RL agent from RSL-RL."""
+
+"""Launch Isaac Sim Simulator first."""
+
+import argparse
+import sys
+
+from isaaclab.app import AppLauncher
+
+# local imports
+import cli_args  # isort: skip
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Train an RL agent with RSL-RL.")
+parser.add_argument("--video", action="store_true", default=False, help="Record videos during training.")
+parser.add_argument("--video_length", type=int, default=200, help="Length of the recorded video (in steps).")
+parser.add_argument(
+    "--disable_fabric", action="store_true", default=False, help="Disable fabric and use USD I/O operations."
+)
+parser.add_argument("--num_envs", type=int, default=None, help="Number of environments to simulate.")
+parser.add_argument("--task", type=str, default=None, help="Name of the task.")
+parser.add_argument("--seed", type=int, default=None, help="Seed used for the environment")
+parser.add_argument(
+    "--use_pretrained_checkpoint",
+    action="store_true",
+    help="Use the pre-trained checkpoint from Nucleus.",
+)
+parser.add_argument("--real-time", action="store_true", default=False, help="Run in real-time, if possible.")
+# append RSL-RL cli arguments
+cli_args.add_rsl_rl_args(parser)
+# append AppLauncher cli args
+AppLauncher.add_app_launcher_args(parser)
+# parse the arguments
+args_cli, hydra_args = parser.parse_known_args()
+# always enable cameras to record video
+if args_cli.video:
+    args_cli.enable_cameras = True
+
+# clear out sys.argv for Hydra
+sys.argv = [sys.argv[0]] + hydra_args
+
+# launch omniverse app
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+import gymnasium as gym
+import os
+import time
+import torch
+
+from rsl_rl.runners import DistillationRunner, OnPolicyRunner
+
+from isaaclab.envs import (
+    DirectMARLEnv,
+    DirectMARLEnvCfg,
+    DirectRLEnvCfg,
+    ManagerBasedRLEnvCfg,
+    multi_agent_to_single_agent,
+)
+from isaaclab.utils.assets import retrieve_file_path
+from isaaclab.utils.dict import print_dict
+from isaaclab.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
+
+from isaaclab_rl.rsl_rl import RslRlBaseRunnerCfg, RslRlVecEnvWrapper, export_policy_as_jit, export_policy_as_onnx
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils import get_checkpoint_path
+from isaaclab_tasks.utils.hydra import hydra_task_config
+
+# PLACEHOLDER: Extension template (do not remove this comment)
+import mbrl.tasks  # noqa: F401
+
+
+@hydra_task_config(args_cli.task, "rsl_rl_cfg_entry_point")
+def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agent_cfg: RslRlBaseRunnerCfg):
+    """Play with RSL-RL agent."""
+    task_name = args_cli.task.split(":")[-1]
+    # override configurations with non-hydra CLI arguments
+    agent_cfg = cli_args.update_rsl_rl_cfg(agent_cfg, args_cli)
+    env_cfg.scene.num_envs = args_cli.num_envs if args_cli.num_envs is not None else env_cfg.scene.num_envs
+
+    # set the environment seed
+    # note: certain randomizations occur in the environment initialization so we set the seed here
+    env_cfg.seed = agent_cfg.seed
+    env_cfg.sim.device = args_cli.device if args_cli.device is not None else env_cfg.sim.device
+
+    # specify directory for logging experiments
+    log_root_path = os.path.join("logs", "rsl_rl", agent_cfg.experiment_name)
+    log_root_path = os.path.abspath(log_root_path)
+    print(f"[INFO] Loading experiment from directory: {log_root_path}")
+    if args_cli.use_pretrained_checkpoint:
+        resume_path = get_published_pretrained_checkpoint("rsl_rl", task_name)
+        if not resume_path:
+            print("[INFO] Unfortunately a pre-trained checkpoint is currently unavailable for this task.")
+            return
+    elif args_cli.checkpoint:
+        resume_path = retrieve_file_path(args_cli.checkpoint)
+    else:
+        resume_path = get_checkpoint_path(log_root_path, agent_cfg.load_run, agent_cfg.load_checkpoint)
+
+    log_dir = os.path.dirname(resume_path)
+
+    # create isaac environment
+    env = gym.make(args_cli.task, cfg=env_cfg, render_mode="rgb_array" if args_cli.video else None)
+
+    # convert to single-agent instance if required by the RL algorithm
+    if isinstance(env.unwrapped, DirectMARLEnv):
+        env = multi_agent_to_single_agent(env)
+
+    # wrap for video recording
+    if args_cli.video:
+        video_kwargs = {
+            "video_folder": os.path.join(log_dir, "videos", "play"),
+            "step_trigger": lambda step: step == 0,
+            "video_length": args_cli.video_length,
+            "disable_logger": True,
+        }
+        print("[INFO] Recording videos during training.")
+        print_dict(video_kwargs, nesting=4)
+        env = gym.wrappers.RecordVideo(env, **video_kwargs)
+
+    # wrap around environment for rsl-rl
+    env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+
+    print(f"[INFO]: Loading model checkpoint from: {resume_path}")
+    # load previously trained model
+    if agent_cfg.class_name == "OnPolicyRunner":
+        runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
+    elif agent_cfg.class_name == "DistillationRunner":
+        runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=None, device=agent_cfg.device)
+    else:
+        raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
+    runner.load(resume_path)
+
+    # obtain the trained policy for inference
+    policy = runner.get_inference_policy(device=env.unwrapped.device)
+
+    dt = env.unwrapped.step_dt
+
+    # reset environment
+    obs = env.get_observations()
+    timestep = 0
+    # simulate environment
+    while simulation_app.is_running():
+        start_time = time.time()
+        # run everything in inference mode
+        with torch.inference_mode():
+            # agent stepping
+            actions = policy(obs)
+            # env stepping
+            obs, _, _, _ = env.step(actions)
+        if args_cli.video:
+            timestep += 1
+            # Exit the play loop after recording one video
+            if timestep == args_cli.video_length:
+                break
+
+        # time delay for real-time evaluation
+        sleep_time = dt - (time.time() - start_time)
+        if args_cli.real_time and sleep_time > 0:
+            time.sleep(sleep_time)
+
+    # close the simulator
+    env.close()
+
+
+if __name__ == "__main__":
+    # run the main function
+    main()
+    # close sim app
+    simulation_app.close()

--- a/robotic_world_model/scripts/reinforcement_learning/rsl_rl/train.py
+++ b/robotic_world_model/scripts/reinforcement_learning/rsl_rl/train.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Script to train RL agent with RSL-RL."""
+
+"""Launch Isaac Sim Simulator first."""
+
+import argparse
+import sys
+
+from isaaclab.app import AppLauncher
+
+# local imports
+import cli_args  # isort: skip
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Train an RL agent with RSL-RL.")
+parser.add_argument("--video", action="store_true", default=False, help="Record videos during training.")
+parser.add_argument("--video_length", type=int, default=200, help="Length of the recorded video (in steps).")
+parser.add_argument("--video_interval", type=int, default=2000, help="Interval between video recordings (in steps).")
+parser.add_argument("--num_envs", type=int, default=None, help="Number of environments to simulate.")
+parser.add_argument("--task", type=str, default=None, help="Name of the task.")
+parser.add_argument("--seed", type=int, default=None, help="Seed used for the environment")
+parser.add_argument("--max_iterations", type=int, default=None, help="RL Policy training iterations.")
+parser.add_argument(
+    "--distributed", action="store_true", default=False, help="Run training with multiple GPUs or nodes."
+)
+parser.add_argument("--system_dynamics_load_path", type=str, default=None, help="Dynamics model load path.")
+# append RSL-RL cli arguments
+cli_args.add_rsl_rl_args(parser)
+# append AppLauncher cli args
+AppLauncher.add_app_launcher_args(parser)
+args_cli, hydra_args = parser.parse_known_args()
+
+# always enable cameras to record video
+if args_cli.video:
+    args_cli.enable_cameras = True
+
+# clear out sys.argv for Hydra
+sys.argv = [sys.argv[0]] + hydra_args
+
+# launch omniverse app
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+"""Check for minimum supported RSL-RL version."""
+
+import importlib.metadata as metadata
+import platform
+
+from packaging import version
+
+# for distributed training, check minimum supported rsl-rl version
+RSL_RL_VERSION = "2.3.1"
+installed_version = metadata.version("rsl-rl-lib")
+if args_cli.distributed and version.parse(installed_version) < version.parse(RSL_RL_VERSION):
+    if platform.system() == "Windows":
+        cmd = [r".\isaaclab.bat", "-p", "-m", "pip", "install", f"rsl-rl-lib=={RSL_RL_VERSION}"]
+    else:
+        cmd = ["./isaaclab.sh", "-p", "-m", "pip", "install", f"rsl-rl-lib=={RSL_RL_VERSION}"]
+    print(
+        f"Please install the correct version of RSL-RL.\nExisting version is: '{installed_version}'"
+        f" and required version is: '{RSL_RL_VERSION}'.\nTo install the correct version, run:"
+        f"\n\n\t{' '.join(cmd)}\n"
+    )
+    exit(1)
+
+"""Rest everything follows."""
+
+import gymnasium as gym
+import os
+import torch
+from datetime import datetime
+
+from rsl_rl.runners import OnPolicyRunner, MBPOOnPolicyRunner
+
+from isaaclab.envs import (
+    DirectMARLEnv,
+    DirectMARLEnvCfg,
+    DirectRLEnvCfg,
+    ManagerBasedRLEnvCfg,
+    multi_agent_to_single_agent,
+)
+from isaaclab.utils.dict import print_dict
+from isaaclab.utils.io import dump_yaml
+
+from isaaclab_rl.rsl_rl import RslRlBaseRunnerCfg, RslRlVecEnvWrapper
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils import get_checkpoint_path
+from isaaclab_tasks.utils.hydra import hydra_task_config
+
+# PLACEHOLDER: Extension template (do not remove this comment)
+import mbrl.tasks  # noqa: F401
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.backends.cudnn.deterministic = False
+torch.backends.cudnn.benchmark = False
+
+
+@hydra_task_config(args_cli.task, "rsl_rl_cfg_entry_point")
+def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agent_cfg: RslRlBaseRunnerCfg):
+    """Train with RSL-RL agent."""
+    # override configurations with non-hydra CLI arguments
+    agent_cfg = cli_args.update_rsl_rl_cfg(agent_cfg, args_cli)
+    env_cfg.scene.num_envs = args_cli.num_envs if args_cli.num_envs is not None else env_cfg.scene.num_envs
+    agent_cfg.max_iterations = (
+        args_cli.max_iterations if args_cli.max_iterations is not None else agent_cfg.max_iterations
+    )
+
+    # set the environment seed
+    # note: certain randomizations occur in the environment initialization so we set the seed here
+    env_cfg.seed = agent_cfg.seed
+    env_cfg.sim.device = args_cli.device if args_cli.device is not None else env_cfg.sim.device
+
+    # multi-gpu training configuration
+    if args_cli.distributed:
+        env_cfg.sim.device = f"cuda:{app_launcher.local_rank}"
+        agent_cfg.device = f"cuda:{app_launcher.local_rank}"
+
+        # set seed to have diversity in different threads
+        seed = agent_cfg.seed + app_launcher.local_rank
+        env_cfg.seed = seed
+        agent_cfg.seed = seed
+
+    # specify directory for logging experiments
+    log_root_path = os.path.join("logs", "rsl_rl", agent_cfg.experiment_name)
+    log_root_path = os.path.abspath(log_root_path)
+    print(f"[INFO] Logging experiment in directory: {log_root_path}")
+    # specify directory for logging runs: {time-stamp}_{run_name}
+    log_dir = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    # The Ray Tune workflow extracts experiment name using the logging line below, hence, do not change it (see PR #2346, comment-2819298849)
+    print(f"Exact experiment name requested from command line: {log_dir}")
+    if agent_cfg.run_name:
+        log_dir += f"_{agent_cfg.run_name}"
+    log_dir = os.path.join(log_root_path, log_dir)
+
+    # create isaac environment
+    env = gym.make(args_cli.task, cfg=env_cfg, render_mode="rgb_array" if args_cli.video else None)
+
+    # convert to single-agent instance if required by the RL algorithm
+    if isinstance(env.unwrapped, DirectMARLEnv):
+        env = multi_agent_to_single_agent(env)
+
+    # save resume path before creating a new log_dir
+    if agent_cfg.resume or agent_cfg.algorithm.class_name == "Distillation":
+        resume_path = get_checkpoint_path(log_root_path, agent_cfg.load_run, agent_cfg.load_checkpoint)
+
+    # wrap for video recording
+    if args_cli.video:
+        video_kwargs = {
+            "video_folder": os.path.join(log_dir, "videos", "train"),
+            "step_trigger": lambda step: step % args_cli.video_interval == 0,
+            "video_length": args_cli.video_length,
+            "disable_logger": True,
+        }
+        print("[INFO] Recording videos during training.")
+        print_dict(video_kwargs, nesting=4)
+        env = gym.wrappers.RecordVideo(env, **video_kwargs)
+
+    # wrap around environment for rsl-rl
+    env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+
+    # create runner from rsl-rl
+    if agent_cfg.class_name == "OnPolicyRunner":
+        runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
+    elif agent_cfg.class_name == "DistillationRunner":
+        runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
+    elif agent_cfg.class_name == "MBPOOnPolicyRunner":
+        agent_cfg.system_dynamics_load_path = args_cli.system_dynamics_load_path if args_cli.system_dynamics_load_path is not None else agent_cfg.system_dynamics_load_path
+        runner = MBPOOnPolicyRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
+    else:
+        raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
+    # write git state to logs
+    runner.add_git_repo_to_log(__file__)
+    # load the checkpoint
+    if agent_cfg.resume or agent_cfg.algorithm.class_name == "Distillation":
+        print(f"[INFO]: Loading model checkpoint from: {resume_path}")
+        # load previously trained model
+        runner.load(resume_path, load_optimizer=False)
+
+    # dump the configuration into log-directory
+    dump_yaml(os.path.join(log_dir, "params", "env.yaml"), env_cfg)
+    dump_yaml(os.path.join(log_dir, "params", "agent.yaml"), agent_cfg)
+
+    # run training
+    runner.learn(num_learning_iterations=agent_cfg.max_iterations, init_at_random_ep_len=True)
+
+    # close the simulator
+    env.close()
+
+
+if __name__ == "__main__":
+    # run the main function
+    main()
+    # close sim app
+    simulation_app.close()

--- a/robotic_world_model/scripts/reinforcement_learning/rsl_rl/visualize.py
+++ b/robotic_world_model/scripts/reinforcement_learning/rsl_rl/visualize.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Script to play a checkpoint if an RL agent from RSL-RL."""
+
+"""Launch Isaac Sim Simulator first."""
+
+import argparse
+import sys
+
+from isaaclab.app import AppLauncher
+
+# local imports
+import cli_args  # isort: skip
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="Train an RL agent with RSL-RL.")
+parser.add_argument("--video", action="store_true", default=False, help="Record videos during training.")
+parser.add_argument("--video_length", type=int, default=200, help="Length of the recorded video (in steps).")
+parser.add_argument(
+    "--disable_fabric", action="store_true", default=False, help="Disable fabric and use USD I/O operations."
+)
+parser.add_argument("--num_envs", type=int, default=None, help="Number of environments to simulate.")
+parser.add_argument("--task", type=str, default=None, help="Name of the task.")
+parser.add_argument("--seed", type=int, default=None, help="Seed used for the environment")
+parser.add_argument(
+    "--use_pretrained_checkpoint",
+    action="store_true",
+    help="Use the pre-trained checkpoint from Nucleus.",
+)
+parser.add_argument("--real-time", action="store_true", default=False, help="Run in real-time, if possible.")
+parser.add_argument("--system_dynamics_load_path", type=str, default=None, help="Dynamics model load path.")
+# append RSL-RL cli arguments
+cli_args.add_rsl_rl_args(parser)
+# append AppLauncher cli args
+AppLauncher.add_app_launcher_args(parser)
+# parse the arguments
+args_cli, hydra_args = parser.parse_known_args()
+# always enable cameras to record video
+if args_cli.video:
+    args_cli.enable_cameras = True
+
+# clear out sys.argv for Hydra
+sys.argv = [sys.argv[0]] + hydra_args
+
+# launch omniverse app
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+import gymnasium as gym
+import os
+import time
+import torch
+
+from rsl_rl.runners import OnPolicyRunner, MBPOOnPolicyRunner
+
+from isaaclab.envs import (
+    DirectMARLEnv,
+    DirectMARLEnvCfg,
+    DirectRLEnvCfg,
+    ManagerBasedRLEnvCfg,
+    multi_agent_to_single_agent,
+)
+from isaaclab.utils.assets import retrieve_file_path
+from isaaclab.utils.dict import print_dict
+from isaaclab.utils.pretrained_checkpoint import get_published_pretrained_checkpoint
+
+from isaaclab_rl.rsl_rl import RslRlBaseRunnerCfg, RslRlVecEnvWrapper, export_policy_as_jit, export_policy_as_onnx
+
+import isaaclab_tasks  # noqa: F401
+from isaaclab_tasks.utils import get_checkpoint_path
+from isaaclab_tasks.utils.hydra import hydra_task_config
+
+from omni.kit.viewport.menubar.lighting.actions import _set_lighting_mode
+_set_lighting_mode("Grey Studio") # Colored Lights
+
+# PLACEHOLDER: Extension template (do not remove this comment)
+import mbrl.tasks  # noqa: F401
+
+
+@hydra_task_config(args_cli.task, "rsl_rl_cfg_entry_point")
+def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agent_cfg: RslRlBaseRunnerCfg):
+    """Play with RSL-RL agent."""
+    task_name = args_cli.task.split(":")[-1]
+    # override configurations with non-hydra CLI arguments
+    agent_cfg = cli_args.update_rsl_rl_cfg(agent_cfg, args_cli)
+    env_cfg.scene.num_envs *= 2
+
+    # set the environment seed
+    # note: certain randomizations occur in the environment initialization so we set the seed here
+    env_cfg.seed = agent_cfg.seed
+    env_cfg.sim.device = args_cli.device if args_cli.device is not None else env_cfg.sim.device
+
+    # specify directory for logging experiments
+    log_root_path = os.path.join("logs", "rsl_rl", agent_cfg.experiment_name)
+    log_root_path = os.path.abspath(log_root_path)
+    print(f"[INFO] Loading experiment from directory: {log_root_path}")
+    if args_cli.use_pretrained_checkpoint:
+        resume_path = get_published_pretrained_checkpoint("rsl_rl", task_name)
+        if not resume_path:
+            print("[INFO] Unfortunately a pre-trained checkpoint is currently unavailable for this task.")
+            return
+    elif args_cli.checkpoint:
+        resume_path = retrieve_file_path(args_cli.checkpoint)
+    else:
+        resume_path = get_checkpoint_path(log_root_path, agent_cfg.load_run, agent_cfg.load_checkpoint)
+
+    log_dir = os.path.dirname(resume_path)
+
+    # create isaac environment
+    env = gym.make(args_cli.task, cfg=env_cfg, render_mode="rgb_array" if args_cli.video else None)
+
+    # convert to single-agent instance if required by the RL algorithm
+    if isinstance(env.unwrapped, DirectMARLEnv):
+        env = multi_agent_to_single_agent(env)
+
+    # wrap for video recording
+    if args_cli.video:
+        video_kwargs = {
+            "video_folder": os.path.join(log_dir, "videos", "play"),
+            "step_trigger": lambda step: step == 0,
+            "video_length": args_cli.video_length,
+            "disable_logger": True,
+        }
+        print("[INFO] Recording videos during training.")
+        print_dict(video_kwargs, nesting=4)
+        env = gym.wrappers.RecordVideo(env, **video_kwargs)
+
+    # wrap around environment for rsl-rl
+    env = RslRlVecEnvWrapper(env, clip_actions=agent_cfg.clip_actions)
+
+    print(f"[INFO]: Loading model checkpoint from: {resume_path}")
+    # load previously trained model
+    if agent_cfg.class_name == "OnPolicyRunner":
+        runner = OnPolicyRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
+    elif agent_cfg.class_name == "DistillationRunner":
+        runner = DistillationRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
+    elif agent_cfg.class_name == "MBPOOnPolicyRunner":
+        agent_cfg.system_dynamics_load_path = args_cli.system_dynamics_load_path if args_cli.system_dynamics_load_path is not None else agent_cfg.system_dynamics_load_path
+        runner = MBPOOnPolicyRunner(env, agent_cfg.to_dict(), log_dir=log_dir, device=agent_cfg.device)
+    else:
+        raise ValueError(f"Unsupported runner class: {agent_cfg.class_name}")
+    runner.load(resume_path, load_optimizer=False)
+
+    # obtain the trained policy for inference
+    policy = runner.get_inference_policy(device=env.unwrapped.device)
+
+    dt = env.unwrapped.step_dt
+
+    # reset environment
+    obs = env.get_observations()
+    timestep = 0
+    env.unwrapped.init_imagination_history(agent_cfg.system_dynamics.history_horizon)
+    # simulate environment
+    while simulation_app.is_running():
+        start_time = time.time()
+        # run everything in inference mode
+        with torch.inference_mode():
+            # agent stepping
+            actions = policy(obs)
+            # env stepping
+            obs, _, _, _ = env.step(actions)
+        if args_cli.video:
+            timestep += 1
+            # Exit the play loop after recording one video
+            if timestep == args_cli.video_length:
+                break
+
+        # time delay for real-time evaluation
+        sleep_time = dt - (time.time() - start_time)
+        if args_cli.real_time and sleep_time > 0:
+            time.sleep(sleep_time)
+
+    # close the simulator
+    env.close()
+
+
+if __name__ == "__main__":
+    # run the main function
+    main()
+    # close sim app
+    simulation_app.close()

--- a/robotic_world_model/scripts/rename_template.py
+++ b/robotic_world_model/scripts/rename_template.py
@@ -1,0 +1,67 @@
+import os
+import sys
+from pathlib import Path
+
+"""This script can be used to rename the template project to a new project name.
+It renames all the occurrences of ext_template (in files, directories, etc.) to the new project name.
+"""
+
+
+def rename_file_contents(root_dir_path: str, old_name: str, new_name: str, exclude_dirs: list = []):
+    """Rename all instances of the old keyword to the new keyword in all files in the root directory.
+
+    Args:
+        root_dir_path (str): The root directory path.
+        old_name (str): The old keyword to replace.
+        new_name (str): The new keyword to replace with.
+    """
+    for dirpath, _, files in os.walk(root_dir_path):
+        if any(exclude_dir in dirpath for exclude_dir in exclude_dirs):
+            continue
+        for file_name in files:
+            if file_name == "rename_template.py":
+                continue
+            try:
+                with open(os.path.join(dirpath, file_name)) as file:
+                    file_contents = file.read()
+                file_contents = file_contents.replace(old_name, new_name)
+                with open(os.path.join(dirpath, file_name), "w") as file:
+                    file.write(file_contents)
+            except Exception as e:
+                print(f"Ignoring {file_name}: {e}")
+                continue
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python rename_template.py <new_name>")
+        sys.exit(1)
+
+    root_dir_path = str(Path(__file__).resolve().parent.parent)
+    old_name = "ext_template"
+    new_name = sys.argv[1]
+
+    print(f"Warning, this script will rename all instances of '{old_name}' to '{new_name}' in {root_dir_path}.")
+    proceed = input("Proceed? (y/n): ")
+
+    if proceed.lower() == "y":
+        # rename the ext_template folder
+        os.rename(
+            os.path.join(root_dir_path, "source", "ext_template", "ext_template"),
+            os.path.join(root_dir_path, "source", "ext_template", new_name),
+        )
+        os.rename(
+            os.path.join(root_dir_path, "source", "ext_template"), os.path.join(root_dir_path, "source", new_name)
+        )
+        os.rename(
+            os.path.join(root_dir_path, "docker", ".env.ext_template.template"),
+            os.path.join(root_dir_path, "docker", f".env.{new_name}.template"),
+        )
+        os.rename(
+            os.path.join(root_dir_path, "docker", ".env.ext_template-dev.template"),
+            os.path.join(root_dir_path, "docker", f".env.{new_name}-dev.template"),
+        )
+        # rename the file contents
+        rename_file_contents(root_dir_path, old_name, new_name, exclude_dirs=[".git", "logs"])
+    else:
+        print("Aborting.")

--- a/robotic_world_model/source/mbrl/config/extension.toml
+++ b/robotic_world_model/source/mbrl/config/extension.toml
@@ -1,0 +1,35 @@
+[package]
+
+# Semantic Versioning is used: https://semver.org/
+version = "0.1.0"
+
+# Description
+category = "isaaclab"
+readme  = "README.md"
+
+title = "Extension Template"
+author = "Isaac Lab Project Developers"
+maintainer = "Isaac Lab Project Developers"
+description="Extension Template for Isaac Lab"
+repository = "https://github.com/isaac-sim/IsaacLabExtensionTemplate.git"
+keywords = ["extension", "template", "isaaclab"]
+
+[dependencies]
+"isaaclab" = {}
+"isaaclab_assets" = {}
+"isaaclab_mimic" = {}
+"isaaclab_rl" = {}
+"isaaclab_tasks" = {}
+# NOTE: Add additional dependencies here
+
+[[python.module]]
+name = "mbrl"
+
+[isaaclab_settings]
+# TODO: Uncomment and list any apt dependencies here.
+#       If none, leave it commented out.
+# apt_deps = ["example_package"]
+# TODO: Uncomment and provide path to a ros_ws
+#       with rosdeps to be installed. If none,
+#       leave it commented out.
+# ros_ws = "path/from/extension_root/to/ros_ws"

--- a/robotic_world_model/source/mbrl/docs/CHANGELOG.rst
+++ b/robotic_world_model/source/mbrl/docs/CHANGELOG.rst
@@ -1,0 +1,10 @@
+Changelog
+---------
+
+0.1.0 (2024-01-29)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Created an initial template for building an extension or project based on Isaac Lab

--- a/robotic_world_model/source/mbrl/mbrl/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/__init__.py
@@ -1,0 +1,9 @@
+"""
+Python module serving as a project/extension template.
+"""
+
+# Register Gym environments.
+from .tasks import *
+
+# Register UI extensions.
+from .ui_extension_example import *

--- a/robotic_world_model/source/mbrl/mbrl/mbrl/envs/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/mbrl/envs/__init__.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sub-package for environment definitions.
+
+Environments define the interface between the agent and the simulation.
+In the simplest case, the environment provides the agent with the current
+observations and executes the actions provided by the agent. However, the
+environment can also provide additional information such as the current
+reward, done flag, and information about the current episode.
+
+There are two types of environment designing workflows:
+
+* **Manager-based**: The environment is decomposed into individual components (or managers)
+  for different aspects (such as computing observations, applying actions, and applying
+  randomization. The users mainly configure the managers and the environment coordinates the
+  managers and calls their functions.
+* **Direct**: The user implements all the necessary functionality directly into a single class
+  directly without the need for additional managers.
+
+Based on these workflows, there are the following environment classes for single and multi-agent RL:
+
+**Single-Agent RL:**
+
+* :class:`ManagerBasedEnv`: The manager-based workflow base environment which only provides the
+  agent with the current observations and executes the actions provided by the agent.
+* :class:`ManagerBasedRLEnv`: The manager-based workflow RL task environment which besides the
+  functionality of the base environment also provides additional Markov Decision Process (MDP)
+  related information such as the current reward, done flag, and information.
+* :class:`DirectRLEnv`: The direct workflow RL task environment which provides implementations for
+  implementing scene setup, computing dones, performing resets, and computing reward and observation.
+
+**Multi-Agent RL (MARL):**
+
+* :class:`DirectMARLEnv`: The direct workflow MARL task environment which provides implementations for
+  implementing scene setup, computing dones, performing resets, and computing reward and observation.
+
+For more information about the workflow design patterns, see the `Task Design Workflows`_ section.
+
+.. _`Task Design Workflows`: https://isaac-sim.github.io/IsaacLab/source/features/task_workflows.html
+"""
+
+from . import mdp
+from .manager_based_mbrl_env import ManagerBasedMBRLEnv
+from .manager_based_visualize_env import ManagerBasedVisualizeEnv

--- a/robotic_world_model/source/mbrl/mbrl/mbrl/envs/manager_based_mbrl_env.py
+++ b/robotic_world_model/source/mbrl/mbrl/mbrl/envs/manager_based_mbrl_env.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# needed to import for allowing type-hinting: np.ndarray | None
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDict
+from typing import Any
+
+from isaaclab.envs.manager_based_rl_env import ManagerBasedRLEnv, ManagerBasedRLEnvCfg
+
+
+class ManagerBasedMBRLEnv(ManagerBasedRLEnv):
+
+
+    def __init__(self, cfg: ManagerBasedRLEnvCfg, render_mode: str | None = None, **kwargs):
+        super().__init__(cfg, render_mode, **kwargs)
+        self.reward_term_names = self.reward_manager.active_terms
+        self._init_additional_attributes()
+        # assigned in runner
+        self.num_imagination_envs = None # type: int
+        self.num_imagination_steps = None # type: int
+        self.max_imagination_episode_length = None # type: int
+        self.imagination_command_resample_interval_range = None # type: list[float] | None
+        self.imagination_state_normalizer = None # type: Any
+        self.imagination_action_normalizer = None # type: Any
+        self.system_dynamics = None # type: Any
+        self.uncertainty_penalty_weight = None # type: float
+        # termination flags
+        self.termination_flags = None # type: torch.Tensor | None
+
+
+    def prepare_imagination(self):
+        self.imagination_common_step_counter = 0
+        self.system_dynamics_model_ids = torch.randint(0, self.system_dynamics.ensemble_size, (1, self.num_imagination_envs, 1), device=self.device)
+        self._init_imagination_reward_buffer()
+        self._init_intervals()
+        self._init_additional_imagination_attributes()
+        self._init_imagination_command()
+        self.last_obs = TensorDict({"policy": torch.zeros(self.num_imagination_envs, self.observation_manager.group_obs_dim["policy"][0])}, batch_size=[self.num_imagination_envs], device=self.device)
+        self.imagination_extras = {}
+        self._reset_imagination_idx(torch.arange(self.num_imagination_envs, device=self.device))
+
+
+    def _reset_imagination_idx(self, env_ids):
+        self.imagination_extras["log"] = dict()
+        self.system_dynamics.reset_partial(env_ids)
+        self.system_dynamics_model_ids[:, env_ids, :] = torch.randint(0, self.system_dynamics.ensemble_size, (1, len(env_ids), 1), device=self.device)
+        info = self._reset_imagination_reward_buffer(env_ids)
+        self.imagination_extras["log"].update(info)
+        self._reset_intervals(env_ids)
+        self._reset_additional_imagination_attributes(env_ids)
+        self.last_obs["policy"][env_ids] = 0.0
+
+
+    def _init_imagination_command(self):
+        for name, term in self.command_manager._terms.items():
+            setattr(self, name, term.sample_command(self.num_imagination_envs))
+
+
+    def _reset_imagination_command(self, env_ids):
+        for name, term in self.command_manager._terms.items():
+            getattr(self, name)[env_ids] = term.sample_command(len(env_ids))
+
+    
+    def _init_imagination_reward_buffer(self):
+        self.imagination_episode_length_buf = torch.zeros(self.num_imagination_envs, device=self.device, dtype=torch.long)
+        self.imagination_episode_sums = {
+            term: torch.zeros(
+                self.num_imagination_envs,
+                device=self.device
+                ) for term in self.reward_term_names
+            }
+        self.imagination_episode_sums["uncertainty"] = torch.zeros(self.num_imagination_envs, device=self.device)
+        self.imagination_reward_per_step = {
+            term: torch.zeros(
+                self.num_imagination_envs,
+                device=self.device
+                ) for term in self.reward_term_names
+            }
+    
+    
+    def _reset_imagination_reward_buffer(self, env_ids):
+        extras = {}
+        self.imagination_episode_length_buf[env_ids] = 0
+        for term in self.imagination_episode_sums.keys():
+            episodic_sum_avg = torch.mean(self.imagination_episode_sums[term][env_ids])
+            extras[term] = episodic_sum_avg / (self.max_imagination_episode_length * self.step_dt)
+            self.imagination_episode_sums[term][env_ids] = 0.0
+        return extras
+
+
+    def _init_intervals(self):
+        if self.imagination_command_resample_interval_range is None:
+            return
+        else:
+            self.imagination_command_resample_intervals = torch.randint(self.imagination_command_resample_interval_range[0], self.imagination_command_resample_interval_range[1], (self.num_imagination_envs,), device=self.device)
+
+
+    def _reset_intervals(self, env_ids):
+        if self.imagination_command_resample_interval_range is None:
+            return
+        else:
+            self.imagination_command_resample_intervals[env_ids] = torch.randint(self.imagination_command_resample_interval_range[0], self.imagination_command_resample_interval_range[1], (len(env_ids),), device=self.device)
+
+    ##From original paper
+    # def imagination_step(self, rollout_action, state_history, action_history):
+    #     rollout_action_normalized = self.imagination_action_normalizer(rollout_action)
+    #     action_history = torch.cat([action_history[:, 1:], rollout_action_normalized.unsqueeze(1)], dim=1)
+    #     imagination_states, aleatoric_uncertainty, self.epistemic_uncertainty, extensions, contacts, terminations = self.system_dynamics.forward(state_history, action_history, self.system_dynamics_model_ids)
+    #     imagination_states_denormalized = self.imagination_state_normalizer.inverse(imagination_states)
+    #     parsed_imagination_states = self._parse_imagination_states(imagination_states_denormalized)
+    #     parsed_extensions = self._parse_extensions(extensions)
+    #     parsed_contacts = self._parse_contacts(contacts)
+    #     self.termination_flags = self._parse_terminations(terminations)
+    #     self._compute_imagination_reward_terms(parsed_imagination_states, rollout_action, parsed_extensions, parsed_contacts)
+    #     rewards, dones, extras = self._post_imagination_step()
+    #     command_ids = self._process_command_env_ids()
+    #     self._reset_imagination_command(command_ids)
+    #     state_history = torch.cat([state_history[:, 1:], imagination_states.unsqueeze(1)], dim=1)
+    #     return self.last_obs, rewards, dones, extras, state_history, action_history, self.epistemic_uncertainty
+    ##Implemented by Tomas to extract infos of the heads
+    def imagination_step(self, rollout_action, state_history, action_history):
+        rollout_action_normalized = self.imagination_action_normalizer(rollout_action)
+        action_history = torch.cat([action_history[:, 1:], rollout_action_normalized.unsqueeze(1)], dim=1)
+        
+        # ── Appel original ────────────────────────────────────────────────────
+        imagination_states, aleatoric_uncertainty, self.epistemic_uncertainty, extensions, contacts, terminations = self.system_dynamics.forward(state_history, action_history, self.system_dynamics_model_ids)
+        
+        # ── Hook : extraction des données par tête ────────────────────────────
+        if getattr(self, "_uncertainty_hook_enabled", False):
+            with torch.no_grad():
+                base_out = self.system_dynamics.state_base(state_history, action_history)
+                _means, _stds = [], []
+                for head in self.system_dynamics.state_heads:
+                    m, s = head(base_out, state_history)
+                    if self.system_dynamics.prediction_type == "sequence":
+                        m, s = m[:, -1], s[:, -1]
+                    _means.append(m.cpu())
+                    _stds.append(s.cpu())
+                self._hook_data = {
+                    "step":             getattr(self, "_hook_step", 0),
+                    "epistemic":        self.epistemic_uncertainty.cpu().numpy(),
+                    "aleatoric":        aleatoric_uncertainty.cpu().numpy(),
+                    "per_head_means":   torch.stack(_means, 0).numpy(),  # [E, B, D]
+                    "per_head_stds":    torch.stack(_stds,  0).numpy(),  # [E, B, D]
+                }
+                self._hook_step = getattr(self, "_hook_step", 0) + 1
+        # ─────────────────────────────────────────────────────────────────────
+        
+        imagination_states_denormalized = self.imagination_state_normalizer.inverse(imagination_states)
+        parsed_imagination_states = self._parse_imagination_states(imagination_states_denormalized)
+        parsed_extensions = self._parse_extensions(extensions)
+        parsed_contacts = self._parse_contacts(contacts)
+        self.termination_flags = self._parse_terminations(terminations)
+        self._compute_imagination_reward_terms(parsed_imagination_states, rollout_action, parsed_extensions, parsed_contacts)
+        rewards, dones, extras = self._post_imagination_step()
+        command_ids = self._process_command_env_ids()
+        self._reset_imagination_command(command_ids)
+        state_history = torch.cat([state_history[:, 1:], imagination_states.unsqueeze(1)], dim=1)
+        return self.last_obs, rewards, dones, extras, state_history, action_history, self.epistemic_uncertainty
+    
+    def _post_imagination_step(self):      
+        self.imagination_episode_length_buf += 1
+        self.imagination_common_step_counter += 1
+        rewards = torch.zeros(self.num_imagination_envs, dtype=torch.float, device=self.device)
+        for term in self.imagination_episode_sums.keys():
+            if term == "uncertainty":
+                rewards += self.uncertainty_penalty_weight * self.epistemic_uncertainty * self.step_dt
+                self.imagination_episode_sums[term] += self.uncertainty_penalty_weight * self.epistemic_uncertainty * self.step_dt
+            else:
+                term_cfg = self.reward_manager.get_term_cfg(term)
+                term_value = self.imagination_reward_per_step[term]
+                rewards += term_cfg.weight * term_value * self.step_dt
+                self.imagination_episode_sums[term] += term_cfg.weight * term_value * self.step_dt
+        
+        terminated = self.termination_flags if self.termination_flags is not None else torch.zeros(self.num_imagination_envs, dtype=torch.bool, device=self.device)
+        time_outs = self.imagination_episode_length_buf >= self.max_imagination_episode_length
+        dones = (terminated | time_outs).to(dtype=torch.long)
+
+        reset_env_ids = (terminated | time_outs).nonzero(as_tuple=False).squeeze(-1)
+        if len(reset_env_ids) > 0:
+            self._reset_imagination_idx(reset_env_ids)
+        self.imagination_extras["time_outs"] = time_outs
+        return rewards, dones, self.imagination_extras
+
+
+    def _process_command_env_ids(self):
+        if self.imagination_command_resample_interval_range is None:
+            return torch.empty(0, dtype=torch.int, device=self.device)
+        else:
+            return (self.imagination_episode_length_buf % self.imagination_command_resample_intervals == 0).nonzero(as_tuple=False).squeeze(-1)
+
+
+    def _init_additional_attributes(self):
+        raise NotImplementedError
+
+
+    def _init_additional_imagination_attributes(self):
+        raise NotImplementedError
+
+
+    def _reset_additional_imagination_attributes(self, env_ids):
+        raise NotImplementedError
+
+
+    def get_imagination_observation(self, state_history, action_history, observation_noise=True):
+        raise NotImplementedError
+    
+
+    def _parse_imagination_states(self, imagination_states_denormalized):
+        raise NotImplementedError
+
+    
+    def _parse_extensions(self, extensions):
+        raise NotImplementedError
+
+
+    def _parse_contacts(self, contacts):
+        raise NotImplementedError
+
+
+    def _parse_terminations(self, terminations):
+        raise NotImplementedError
+
+
+    def _compute_imagination_reward_terms(self, parsed_imagination_states, rollout_action, parsed_extensions, parsed_contacts):
+        raise NotImplementedError

--- a/robotic_world_model/source/mbrl/mbrl/mbrl/envs/manager_based_visualize_env.py
+++ b/robotic_world_model/source/mbrl/mbrl/mbrl/envs/manager_based_visualize_env.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# needed to import for allowing type-hinting: np.ndarray | None
+from __future__ import annotations
+
+import torch
+
+from isaaclab.envs.common import VecEnvStepReturn
+from .manager_based_mbrl_env import ManagerBasedMBRLEnv, ManagerBasedRLEnvCfg
+
+
+class ManagerBasedVisualizeEnv(ManagerBasedMBRLEnv):
+    
+    
+    def __init__(self, cfg: ManagerBasedRLEnvCfg, render_mode: str | None = None, **kwargs):
+        super().__init__(cfg, render_mode, **kwargs)
+        self.env_ids_real = torch.arange(0, self.num_envs, 2, device=self.device)
+        self.env_ids_imagination = torch.arange(1, self.num_envs, 2, device=self.device)
+
+        
+    def init_imagination_history(self, history_horizon):
+        self.imagination_state_history = torch.zeros(self.num_envs // 2, history_horizon, self.observation_manager.group_obs_dim["system_state"][0], device=self.device)
+        self.imagination_action_history = torch.zeros(self.num_envs // 2, history_horizon, self.observation_manager.group_obs_dim["system_action"][0], device=self.device)
+        
+    
+    def _sync_imagination_history(self, env_ids_real):
+        self.imagination_state_history[env_ids_real // 2] = 0.0
+        self.imagination_action_history[env_ids_real // 2] = 0.0
+        self.imagination_state_history[env_ids_real // 2, -1] = self.imagination_state_normalizer(self.observation_manager.compute()["system_state"])[env_ids_real]
+
+
+    def step(self, action: torch.Tensor) -> VecEnvStepReturn:
+        """Execute one time-step of the environment's dynamics and reset terminated environments.
+
+        Unlike the :class:`ManagerBasedEnv.step` class, the function performs the following operations:
+
+        1. Process the actions.
+        2. Perform physics stepping.
+        3. Perform rendering if gui is enabled.
+        4. Update the environment counters and compute the rewards and terminations.
+        5. Reset the environments that terminated.
+        6. Compute the observations.
+        7. Return the observations, rewards, resets and extras.
+
+        Args:
+            action: The actions to apply on the environment. Shape is (num_envs, action_dim).
+
+        Returns:
+            A tuple containing the observations, rewards, resets (terminated and truncated) and extras.
+        """
+        # process actions
+        self.action_manager.process_action(action.to(self.device))
+
+        # check if we need to do rendering within the physics loop
+        # note: checked here once to avoid multiple checks within the loop
+        is_rendering = self.sim.has_gui() or self.sim.has_rtx_sensors()
+
+        # perform physics stepping
+        for i in range(self.cfg.decimation):
+            self._sim_step_counter += 1
+            # set actions into buffers
+            self.action_manager.apply_action()
+            # set actions into simulator
+            self.scene.write_data_to_sim()
+            # write imagination states
+            if i == self.cfg.decimation - 1:
+                self._update_imagination_envs(action)
+            # simulate
+            self.sim.step(render=False)
+            # render between steps only if the GUI or an RTX sensor needs it
+            # note: we assume the render interval to be the shortest accepted rendering interval.
+            #    If a camera needs rendering at a faster frequency, this will lead to unexpected behavior.
+            if self._sim_step_counter % self.cfg.sim.render_interval == 0 and is_rendering:
+                self.sim.render()
+            # update buffers at sim dt
+            self.scene.update(dt=self.physics_dt)
+
+        # post-step:
+        # -- update env counters (used for curriculum generation)
+        self.episode_length_buf += 1  # step in current episode (per env)
+        self.common_step_counter += 1  # total step (common for all envs)
+        # -- check terminations
+        self.reset_buf = self.termination_manager.compute()
+        self.reset_terminated = self.termination_manager.terminated
+        self.reset_time_outs = self.termination_manager.time_outs
+        # -- reward computation
+        self.reward_buf = self.reward_manager.compute(dt=self.step_dt)
+
+        # -- reset envs that terminated/timed-out and log the episode information
+        reset_env_ids = self.reset_buf.nonzero(as_tuple=False).squeeze(-1)
+        if len(reset_env_ids) > 0:
+            uniques, counts = torch.cat([reset_env_ids, self.env_ids_real]).unique(return_counts=True)
+            env_ids_real = uniques[counts > 1]
+            env_ids_imagination = env_ids_real + 1
+            env_ids = torch.vstack([env_ids_real, env_ids_imagination]).T.flatten()
+            if len(env_ids) > 0:
+                self._reset_idx(env_ids)
+            # if sensors are added to the scene, make sure we render to reflect changes in reset
+            if self.sim.has_rtx_sensors() and self.cfg.rerender_on_reset:
+                self.sim.render()
+
+        # -- update command
+        self.command_manager.compute(dt=self.step_dt)
+        # -- step interval events
+        if "interval" in self.event_manager.available_modes:
+            self.event_manager.apply(mode="interval", dt=self.step_dt)
+        # -- compute observations
+        # note: done after reset to get the correct observations for reset envs
+        self.obs_buf = self.observation_manager.compute()
+        if len(reset_env_ids) > 0 and len(env_ids_real) > 0:
+            self._sync_imagination_history(env_ids_real)
+
+        # return observations, rewards, resets and extras
+        return self.obs_buf, self.reward_buf, self.reset_terminated, self.reset_time_outs, self.extras
+
+
+    def _update_imagination_envs(self, action):
+        self.num_imagination_envs = len(self.env_ids_imagination)
+        rollout_action = action[self.env_ids_imagination]
+        self.imagination_action_history = torch.cat([self.imagination_action_history[:, 1:].clone(), self.imagination_action_normalizer(rollout_action).unsqueeze(1)], dim=1)
+        if self.system_dynamics.architecture_config["type"] in ["rnn", "rssm"]:
+            self.imagination_state_history = self.imagination_state_history[:, -1].unsqueeze(1)
+            self.imagination_action_history = self.imagination_action_history[:, -1].unsqueeze(1)
+        imagination_states, *_ = self.system_dynamics.forward(self.imagination_state_history, self.imagination_action_history)
+        imagination_states_denormalized = self.imagination_state_normalizer.inverse(imagination_states)
+        parsed_imagination_states = self._parse_imagination_states(imagination_states_denormalized)
+        self._reset_imagination_sim(parsed_imagination_states)
+        self.imagination_state_history = torch.cat([self.imagination_state_history[:, 1:].clone(), imagination_states.unsqueeze(1)], dim=1)
+
+
+    def _reset_imagination_sim(self, parsed_imagination_states):
+        raise NotImplementedError

--- a/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sub-module with implementation of manager terms.
+
+The functions can be provided to different managers that are responsible for the
+different aspects of the MDP. These include the observation, reward, termination,
+actions, events and curriculum managers.
+
+The terms are defined under the ``envs`` module because they are used to define
+the environment. However, they are not part of the environment directly, but
+are used to define the environment through their managers.
+
+"""
+
+from isaaclab.envs.mdp import *  # noqa: F401, F403
+from .commands import *  # noqa: F401, F403
+from .events import *  # noqa: F401, F403
+from .observations import *  # noqa: F401, F403

--- a/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/commands/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/commands/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Various command terms that can be used in the environment."""
+
+from .pose_command import UniformPoseCommand_Visualize
+from .velocity_command import UniformVelocityCommand_Visualize, SampleUniformVelocityCommand

--- a/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/commands/pose_command.py
+++ b/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/commands/pose_command.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sub-module containing command generators for pose tracking."""
+
+from __future__ import annotations
+
+import torch
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from isaaclab.markers import VisualizationMarkers, CUBOID_MARKER_CFG
+from isaaclab.envs.mdp.commands.pose_command import UniformPoseCommand
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedEnv
+
+    from isaaclab.envs.mdp.commands.commands_cfg import UniformPoseCommandCfg
+
+
+class UniformPoseCommand_Visualize(UniformPoseCommand):
+    def __init__(self, cfg: UniformPoseCommandCfg, env: ManagerBasedEnv):
+        super().__init__(cfg, env)
+        self.env = env
+        
+    def _resample_command(self, env_ids: Sequence[int]):
+        # intersect the reset envs with only the real envs
+        uniques, counts = torch.cat([env_ids, self.env.env_ids_real]).unique(return_counts=True)
+        env_ids = uniques[counts > 1]
+        super()._resample_command(env_ids)
+        self.pose_command_b[env_ids + 1] = self.pose_command_b[env_ids].clone()
+
+    def _set_debug_vis_impl(self, debug_vis: bool):
+        super()._set_debug_vis_impl(debug_vis)
+        if debug_vis:
+            if not hasattr(self, "real_visualizer"):
+                marker_cfg = CUBOID_MARKER_CFG.copy()
+                marker_cfg.markers["cuboid"].visual_material.diffuse_color = (0.0, 1.0, 0.0)
+                marker_cfg.prim_path = "/Visuals/Model/real"
+                self.real_visualizer = VisualizationMarkers(marker_cfg)
+                # -- current body pose
+                marker_cfg.markers["cuboid"].visual_material.diffuse_color = (1.0, 0.0, 0.0)
+                marker_cfg.prim_path = "/Visuals/Model/imagination"
+                self.imagination_visualizer = VisualizationMarkers(marker_cfg)
+            # set their visibility to true
+            self.real_visualizer.set_visibility(True)
+            self.imagination_visualizer.set_visibility(True)
+        else:
+            if hasattr(self, "real_visualizer"):
+                self.real_visualizer.set_visibility(False)
+                self.imagination_visualizer.set_visibility(False)
+    
+    def _debug_vis_callback(self, event):
+        super()._debug_vis_callback(event)
+        # update the markers
+        # -- real
+        marker_position = self.robot.data.root_pos_w.clone()
+        marker_position[:, 2] += 1.0
+        self.real_visualizer.visualize(marker_position[self.env.env_ids_real])
+        # -- imagination
+        self.imagination_visualizer.visualize(marker_position[self.env.env_ids_imagination])

--- a/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/commands/velocity_command.py
+++ b/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/commands/velocity_command.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Sub-module containing command generators for the velocity-based locomotion task."""
+
+from __future__ import annotations
+
+import torch
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from isaaclab.markers import VisualizationMarkers, CUBOID_MARKER_CFG
+from isaaclab.envs.mdp.commands.velocity_command import UniformVelocityCommand
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedEnv
+
+    from isaaclab.envs.mdp.commands.commands_cfg import UniformVelocityCommandCfg
+
+
+class UniformVelocityCommand_Visualize(UniformVelocityCommand):
+    def __init__(self, cfg: UniformVelocityCommandCfg, env: ManagerBasedEnv):
+        super().__init__(cfg, env)
+        self.env = env
+        
+    def _resample_command(self, env_ids: Sequence[int]):
+        # intersect the reset envs with only the real envs
+        uniques, counts = torch.cat([env_ids, self.env.env_ids_real]).unique(return_counts=True)
+        env_ids = uniques[counts > 1]
+        super()._resample_command(env_ids)
+        self.vel_command_b[env_ids + 1] = self.vel_command_b[env_ids].clone()
+        # heading target
+        if self.cfg.heading_command:
+            self.heading_target[env_ids + 1] = self.heading_target[env_ids].clone()
+            # update heading envs
+            self.is_heading_env[env_ids + 1] = self.is_heading_env[env_ids].clone()
+        # update standing envs
+        self.is_standing_env[env_ids + 1] = self.is_standing_env[env_ids].clone()
+
+
+    def _set_debug_vis_impl(self, debug_vis: bool):
+        super()._set_debug_vis_impl(debug_vis)
+        if debug_vis:
+            if not hasattr(self, "real_visualizer"):
+                marker_cfg = CUBOID_MARKER_CFG.copy()
+                marker_cfg.markers["cuboid"].visual_material.diffuse_color = (0.0, 1.0, 0.0)
+                marker_cfg.prim_path = "/Visuals/Model/real"
+                self.real_visualizer = VisualizationMarkers(marker_cfg)
+                # -- current body pose
+                marker_cfg.markers["cuboid"].visual_material.diffuse_color = (1.0, 0.0, 0.0)
+                marker_cfg.prim_path = "/Visuals/Model/imagination"
+                self.imagination_visualizer = VisualizationMarkers(marker_cfg)
+            # set their visibility to true
+            self.real_visualizer.set_visibility(True)
+            self.imagination_visualizer.set_visibility(True)
+        else:
+            if hasattr(self, "real_visualizer"):
+                self.real_visualizer.set_visibility(False)
+                self.imagination_visualizer.set_visibility(False)
+    
+
+    def _debug_vis_callback(self, event):
+        super()._debug_vis_callback(event)
+        # update the markers
+        # -- real
+        marker_position = self.robot.data.root_pos_w.clone()
+        marker_position[:, 2] += 1.0
+        self.real_visualizer.visualize(marker_position[self.env.env_ids_real])
+        # -- imagination
+        self.imagination_visualizer.visualize(marker_position[self.env.env_ids_imagination])
+
+
+class SampleUniformVelocityCommand(UniformVelocityCommand):
+    
+    def sample_command(self, num_envs: int):
+        # sample velocity commands
+        r = torch.empty(num_envs, device=self.device)
+        vel_command_b = torch.zeros(num_envs, 3, device=self.device)
+        # -- linear velocity - x direction
+        vel_command_b[:, 0] = r.uniform_(*self.cfg.ranges.lin_vel_x)
+        # -- linear velocity - y direction
+        vel_command_b[:, 1] = r.uniform_(*self.cfg.ranges.lin_vel_y)
+        # -- ang vel yaw - rotation around z
+        vel_command_b[:, 2] = r.uniform_(*self.cfg.ranges.ang_vel_z)
+        return vel_command_b
+

--- a/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/events.py
+++ b/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/events.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Common functions that can be used to enable different events.
+
+Events include anything related to altering the simulation state. This includes changing the physics
+materials, applying external forces, and resetting the state of the asset.
+
+The functions can be passed to the :class:`isaaclab.managers.EventTermCfg` object to enable
+the event introduced by the function.
+"""
+
+from __future__ import annotations
+
+import torch
+from typing import TYPE_CHECKING
+
+import isaaclab.utils.math as math_utils
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.managers import SceneEntityCfg
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedEnv
+
+
+def reset_root_state_uniform_visualize(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    pose_range: dict[str, tuple[float, float]],
+    velocity_range: dict[str, tuple[float, float]],
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+):
+    # intersect the reset envs with only the real envs
+    uniques, counts = torch.cat([env_ids, env.env_ids_real]).unique(return_counts=True)
+    env_ids = uniques[counts > 1]
+    # extract the used quantities (to enable type-hinting)
+    asset: RigidObject | Articulation = env.scene[asset_cfg.name]
+    # get default root state
+    root_states = asset.data.default_root_state[env_ids].clone()
+
+    # poses
+    range_list = [pose_range.get(key, (0.0, 0.0)) for key in ["x", "y", "z", "roll", "pitch", "yaw"]]
+    ranges = torch.tensor(range_list, device=asset.device)
+    rand_samples = math_utils.sample_uniform(ranges[:, 0], ranges[:, 1], (len(env_ids), 6), device=asset.device)
+
+    positions = root_states[:, 0:3] + rand_samples[:, 0:3]
+    orientations = math_utils.quat_from_euler_xyz(rand_samples[:, 3], rand_samples[:, 4], rand_samples[:, 5])
+
+    # velocities
+    range_list = [velocity_range.get(key, (0.0, 0.0)) for key in ["x", "y", "z", "roll", "pitch", "yaw"]]
+    ranges = torch.tensor(range_list, device=asset.device)
+    rand_samples = math_utils.sample_uniform(ranges[:, 0], ranges[:, 1], (len(env_ids), 6), device=asset.device)
+
+    velocities = root_states[:, 7:13] + rand_samples
+    
+    env_ids = torch.vstack([env_ids, env_ids + 1]).T.flatten()
+    positions = torch.repeat_interleave(positions, 2, dim=0) + env.scene.env_origins[env_ids]
+    orientations = torch.repeat_interleave(orientations, 2, dim=0)
+    velocities = torch.repeat_interleave(velocities, 2, dim=0)
+
+    # set into the physics simulation
+    asset.write_root_pose_to_sim(torch.cat([positions, orientations], dim=-1), env_ids=env_ids)
+    asset.write_root_velocity_to_sim(velocities, env_ids=env_ids)
+
+
+def reset_root_state_to_specified(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    positions: torch.Tensor,
+    orientations: torch.Tensor,
+    velocities: torch.Tensor,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+):
+    # extract the used quantities (to enable type-hinting)
+    asset: RigidObject | Articulation = env.scene[asset_cfg.name]
+
+    # set into the physics simulation
+    asset.write_root_pose_to_sim(torch.cat([positions, orientations], dim=-1), env_ids=env_ids)
+    asset.write_root_velocity_to_sim(velocities, env_ids=env_ids)
+
+
+def reset_root_velocity_to_specified(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    velocities: torch.Tensor,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+):
+    # extract the used quantities (to enable type-hinting)
+    asset: RigidObject | Articulation = env.scene[asset_cfg.name]
+
+    # set into the physics simulation
+    asset.write_root_velocity_to_sim(velocities, env_ids=env_ids)
+
+
+def reset_joints_by_scale_visualize(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    position_range: tuple[float, float],
+    velocity_range: tuple[float, float],
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+):
+    # intersect the reset envs with only the real envs
+    uniques, counts = torch.cat([env_ids, env.env_ids_real]).unique(return_counts=True)
+    env_ids = uniques[counts > 1]
+    # extract the used quantities (to enable type-hinting)
+    asset: Articulation = env.scene[asset_cfg.name]
+    # get default joint state
+    joint_pos = asset.data.default_joint_pos[env_ids].clone()
+    joint_vel = asset.data.default_joint_vel[env_ids].clone()
+
+    # scale these values randomly
+    joint_pos *= math_utils.sample_uniform(*position_range, joint_pos.shape, joint_pos.device)
+    joint_vel *= math_utils.sample_uniform(*velocity_range, joint_vel.shape, joint_vel.device)
+
+    # clamp joint pos to limits
+    joint_pos_limits = asset.data.soft_joint_pos_limits[env_ids]
+    joint_pos = joint_pos.clamp_(joint_pos_limits[..., 0], joint_pos_limits[..., 1])
+    # clamp joint vel to limits
+    joint_vel_limits = asset.data.soft_joint_vel_limits[env_ids]
+    joint_vel = joint_vel.clamp_(-joint_vel_limits, joint_vel_limits)
+    
+    env_ids = torch.vstack([env_ids, env_ids + 1]).T.flatten()
+    joint_pos = torch.repeat_interleave(joint_pos, 2, dim=0)
+    joint_vel = torch.repeat_interleave(joint_vel, 2, dim=0)
+    
+    # set into the physics simulation
+    asset.write_joint_state_to_sim(joint_pos, joint_vel, env_ids=env_ids)
+
+
+def reset_joints_to_specified(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    joint_pos: torch.Tensor,
+    joint_vel: torch.Tensor,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+):
+    # extract the used quantities (to enable type-hinting)
+    asset: Articulation = env.scene[asset_cfg.name]
+    # clamp joint pos to limits
+    joint_pos_limits = asset.data.soft_joint_pos_limits[env_ids]
+    joint_pos = joint_pos.clamp_(joint_pos_limits[..., 0], joint_pos_limits[..., 1])
+
+    # set into the physics simulation
+    asset.write_joint_state_to_sim(joint_pos, joint_vel, env_ids=env_ids)
+
+
+def reset_joints_by_offset_visualize(
+    env: ManagerBasedEnv,
+    env_ids: torch.Tensor,
+    position_range: tuple[float, float],
+    velocity_range: tuple[float, float],
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+):
+    # intersect the reset envs with only the real envs
+    uniques, counts = torch.cat([env_ids, env.env_ids_real]).unique(return_counts=True)
+    env_ids = uniques[counts > 1]
+    # extract the used quantities (to enable type-hinting)
+    asset: Articulation = env.scene[asset_cfg.name]
+
+    # get default joint state
+    joint_pos = asset.data.default_joint_pos[env_ids].clone()
+    joint_vel = asset.data.default_joint_vel[env_ids].clone()
+
+    # bias these values randomly
+    joint_pos += math_utils.sample_uniform(*position_range, joint_pos.shape, joint_pos.device)
+    joint_vel += math_utils.sample_uniform(*velocity_range, joint_vel.shape, joint_vel.device)
+
+    # clamp joint pos to limits
+    joint_pos_limits = asset.data.soft_joint_pos_limits[env_ids]
+    joint_pos = joint_pos.clamp_(joint_pos_limits[..., 0], joint_pos_limits[..., 1])
+    # clamp joint vel to limits
+    joint_vel_limits = asset.data.soft_joint_vel_limits[env_ids]
+    joint_vel = joint_vel.clamp_(-joint_vel_limits, joint_vel_limits)
+
+    env_ids = torch.vstack([env_ids, env_ids + 1]).T.flatten()
+    joint_pos = torch.repeat_interleave(joint_pos, 2, dim=0)
+    joint_vel = torch.repeat_interleave(joint_vel, 2, dim=0)
+
+    # set into the physics simulation
+    asset.write_joint_state_to_sim(joint_pos, joint_vel, env_ids=env_ids)

--- a/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/observations.py
+++ b/robotic_world_model/source/mbrl/mbrl/mbrl/envs/mdp/observations.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Common functions that can be used to create observation terms.
+
+The functions can be passed to the :class:`isaaclab.managers.ObservationTermCfg` object to enable
+the observation introduced by the function.
+"""
+
+from __future__ import annotations
+
+import torch
+from typing import TYPE_CHECKING
+
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.sensors import ContactSensor
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedEnv, ManagerBasedRLEnv
+
+
+def body_contact(env: ManagerBasedEnv, threshold: float, sensor_cfg: SceneEntityCfg) -> torch.Tensor:
+    """Contact status of the body of the asset."""
+    # extract the used quantities (to enable type-hinting)
+    contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+    net_contact_forces = contact_sensor.data.net_forces_w_history
+    is_contact = torch.max(torch.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] > threshold
+    return is_contact

--- a/robotic_world_model/source/mbrl/mbrl/rl/rsl_rl/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/rl/rsl_rl/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Wrappers and utilities to configure an environment for RSL-RL library.
+
+The following example shows how to wrap an environment for RSL-RL:
+
+.. code-block:: python
+
+    from isaaclab_rl.rsl_rl import RslRlVecEnvWrapper
+
+    env = RslRlVecEnvWrapper(env)
+
+"""
+
+from .rl_cfg import *

--- a/robotic_world_model/source/mbrl/mbrl/rl/rsl_rl/rl_cfg.py
+++ b/robotic_world_model/source/mbrl/mbrl/rl/rsl_rl/rl_cfg.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from dataclasses import MISSING
+from typing import Literal
+
+from isaaclab.utils import configclass
+
+
+@configclass
+class RslRlSystemDynamicsCfg:
+    """Configuration for the system dynamics networks."""
+    
+    ensemble_size: int = MISSING
+    """The ensemble size of the system dynamics network."""
+
+    history_horizon: int = MISSING
+    """The prediction horizon of the system dynamics network."""
+
+    architecture_config: dict = MISSING
+    """The architecture configuration of the system dynamics network."""
+    
+    freeze_auxiliary: bool = MISSING
+    """Whether to freeze the auxiliary networks."""
+
+
+@configclass
+class RslRlNormalizerCfg:
+    """Configuration for the normalizer."""
+
+    mean: list[float] = MISSING
+    """The mean of the normalizer."""
+
+    std: list[float] = MISSING
+    """The std of the normalizer."""
+
+
+@configclass
+class RslRlMbrlImaginationCfg:
+    """Configuration for the imagination."""
+    
+    num_envs: int = MISSING
+    """The number of environments for the imagination."""
+    
+    num_steps_per_env: int = MISSING
+    """The number of steps for the imagination."""
+    
+    max_episode_length: int = MISSING
+    """The maximum episode length for the imagination."""
+
+    command_resample_interval_range: list[float] | None = MISSING
+    """The resample interval range for the command."""
+    
+    uncertainty_penalty_weight: float = MISSING
+    """The weight for the uncertainty penalty."""
+    
+    state_normalizer: RslRlNormalizerCfg = MISSING
+    """The normalizer for the state."""
+    
+    action_normalizer: RslRlNormalizerCfg = MISSING
+    """The normalizer for the action."""
+
+
+@configclass
+class RslRlMbrlPpoAlgorithmCfg:
+    """Configuration for the PPO algorithm."""
+
+    class_name: str = "MBPOPPO"
+    """The algorithm class name. Default is PPO."""
+
+    value_loss_coef: float = MISSING
+    """The coefficient for the value loss."""
+
+    use_clipped_value_loss: bool = MISSING
+    """Whether to use clipped value loss."""
+
+    clip_param: float = MISSING
+    """The clipping parameter for the policy."""
+
+    entropy_coef: float = MISSING
+    """The coefficient for the entropy loss."""
+
+    num_learning_epochs: int = MISSING
+    """The number of learning epochs per update."""
+
+    num_mini_batches: int = MISSING
+    """The number of mini-batches per update."""
+
+    policy_learning_rate: float = MISSING
+    """The learning rate for the policy."""
+
+    system_dynamics_learning_rate: float = MISSING
+    """The learning rate for the system dynamics."""
+    
+    system_dynamics_weight_decay: float = MISSING
+    """The weight decay for the system dynamics."""
+
+    schedule: str = MISSING
+    """The learning rate schedule."""
+
+    gamma: float = MISSING
+    """The discount factor."""
+
+    lam: float = MISSING
+    """The lambda parameter for Generalized Advantage Estimation (GAE)."""
+
+    desired_kl: float = MISSING
+    """The desired KL divergence."""
+
+    max_grad_norm: float = MISSING
+    """The maximum gradient norm."""
+    
+    system_dynamics_forecast_horizon: int = MISSING
+    """The forecast horizon for the system dynamics."""
+    
+    system_dynamics_loss_weights: dict[str, float] = MISSING
+    """The loss weights for the system dynamics."""
+    
+    system_dynamics_num_mini_batches: int = MISSING
+    """The number of mini-batches for the system dynamics."""
+    
+    system_dynamics_mini_batch_size: int = MISSING
+    """The mini-batch size for the system dynamics."""
+    
+    system_dynamics_replay_buffer_size: int = MISSING
+    """The replay buffer size for the system dynamics."""
+    
+    system_dynamics_num_eval_trajectories: int = MISSING
+    """The number of evaluation trajectories for the system dynamics."""
+    
+    system_dynamics_len_eval_trajectory: int = MISSING
+    """The length of the evaluation trajectory for the system dynamics."""
+    
+    system_dynamics_eval_traj_noise_scale: list[float] = MISSING
+    """The noise scale for the evaluation trajectory for the system dynamics."""

--- a/robotic_world_model/source/mbrl/mbrl/tasks/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/__init__.py
@@ -1,0 +1,16 @@
+"""Package containing task implementations for various robotic environments."""
+
+import os
+import toml
+
+from isaaclab_tasks.utils import import_packages
+
+##
+# Register Gym environments.
+##
+
+
+# The blacklist is used to prevent importing configs from sub-packages
+_BLACKLIST_PKGS = ["utils"]
+# Import all configs in this package
+import_packages(__name__, _BLACKLIST_PKGS)

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Config-based workflow environments.
+"""
+
+import gymnasium as gym

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/__init__.py
@@ -1,0 +1,3 @@
+"""Locomotion environments for legged robots."""
+
+from .velocity import *  # noqa

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/__init__.py
@@ -1,0 +1,7 @@
+"""Locomotion environments with velocity-tracking commands.
+
+These environments are based on the `legged_gym` environments provided by Rudin et al.
+
+Reference:
+    https://github.com/leggedrobotics/legged_gym
+"""

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/__init__.py
@@ -1,0 +1,4 @@
+"""Configurations for velocity-based locomotion environments."""
+
+# We leave this file empty since we don't want to expose any configs in this package directly.
+# We still need this file to import the "config" module in the parent package.

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/anymal_d/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/anymal_d/__init__.py
@@ -1,0 +1,47 @@
+import gymnasium as gym
+
+from . import agents
+
+##
+# Register Gym environments.
+##
+
+gym.register(
+    id="Template-Isaac-Velocity-Flat-Anymal-D-Init-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.flat_env_cfg:AnymalDFlatEnvCfg_INIT",
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDFlatPPORunnerCfg",
+    },
+)
+
+gym.register(
+    id="Template-Isaac-Velocity-Flat-Anymal-D-Pretrain-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.flat_env_cfg:AnymalDFlatEnvCfg_PRETRAIN",
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDFlatPPOPretrainRunnerCfg",
+    },
+)
+
+gym.register(
+    id="Template-Isaac-Velocity-Flat-Anymal-D-Finetune-v0",
+    entry_point="mbrl.tasks.manager_based.locomotion.velocity.config.anymal_d.envs.anymal_d_manager_based_mbrl_env:ANYmalDManagerBasedMBRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.flat_env_cfg:AnymalDFlatEnvCfg_FINETUNE",
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDFlatPPOFinetuneRunnerCfg",
+    },
+)
+
+gym.register(
+    id="Template-Isaac-Velocity-Flat-Anymal-D-Visualize-v0",
+    entry_point="mbrl.tasks.manager_based.locomotion.velocity.config.anymal_d.envs.anymal_d_manager_based_visualize_env:ANYmalDManagerBasedVisualizeEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.flat_env_cfg:AnymalDFlatEnvCfg_VISUALIZE",
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:AnymalDFlatPPOVisualizeRunnerCfg",
+    },
+)

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/anymal_d/agents/rsl_rl_ppo_cfg.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/anymal_d/agents/rsl_rl_ppo_cfg.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.utils import configclass
+
+from isaaclab_tasks.manager_based.locomotion.velocity.config.anymal_d.agents.rsl_rl_ppo_cfg import AnymalDFlatPPORunnerCfg
+from mbrl.rl.rsl_rl import (
+    RslRlSystemDynamicsCfg,
+    RslRlNormalizerCfg,
+    RslRlMbrlImaginationCfg,
+    RslRlMbrlPpoAlgorithmCfg,
+)
+
+
+@configclass
+class AnymalDFlatPPOPretrainRunnerCfg(AnymalDFlatPPORunnerCfg):
+    class_name: str = "MBPOOnPolicyRunner"
+
+    system_dynamics = RslRlSystemDynamicsCfg(
+        ensemble_size=1,
+        history_horizon=32,
+        architecture_config = {
+            "type": "rnn",
+            "rnn_type": "gru",
+            "rnn_num_layers": 2,
+            "rnn_hidden_size": 256,
+            "state_mean_shape": [128],
+            "state_logstd_shape": [128],
+            "extension_shape": [128],
+            "contact_shape": [128],
+            "termination_shape": [128],
+        },
+        freeze_auxiliary=False,
+    )
+    imagination = RslRlMbrlImaginationCfg(
+        num_envs=0,
+        num_steps_per_env=0,
+        max_episode_length=0,
+        command_resample_interval_range=None,
+        uncertainty_penalty_weight=-0.0,
+        state_normalizer=RslRlNormalizerCfg(
+            mean=[
+                0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0,
+                0.0, 0.0, -1.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                -2.0, -2.0, 2.0, 2.0, -6.0, 8.0, -6.0, 8.0, 12.0, -12.0, 12.0, -12.0,
+                ],
+            std=[
+                0.5, 0.5, 0.1,
+                0.3, 0.3, 0.5,
+                0.02, 0.02, 0.04,
+                0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15, 0.15,
+                1.0, 1.0, 1.0, 1.0, 1.5, 1.5, 1.5, 1.5, 2.5, 2.5, 2.5, 2.5,
+                15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0, 15.0,
+                ],
+        ),
+        action_normalizer=RslRlNormalizerCfg(
+            mean=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            std=[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+        )
+    )
+    algorithm = RslRlMbrlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.005,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        policy_learning_rate=1.0e-3,
+        system_dynamics_learning_rate=1.0e-3,
+        system_dynamics_weight_decay=0.0,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+        system_dynamics_forecast_horizon=8,
+        system_dynamics_loss_weights={"state": 1.0, "sequence": 1.0, "bound": 1.0, "kl": 0.1, "extension": 1.0, "contact": 1.0, "termination": 1.0},
+        system_dynamics_num_mini_batches=20,
+        system_dynamics_mini_batch_size=5000,
+        system_dynamics_replay_buffer_size=1000,
+        system_dynamics_num_eval_trajectories=100,
+        system_dynamics_len_eval_trajectory=400,
+        system_dynamics_eval_traj_noise_scale=[0.1, 0.2, 0.4, 0.5, 0.8],
+    )
+    run_name = "pretrain"
+    load_system_dynamics = False
+    system_dynamics_load_path = None
+    system_dynamics_warmup_iterations = 0
+    system_dynamics_num_visualizations = 4
+    system_dynamics_state_idx_dict = {
+        r"$v$\n$[m/s]$": [0, 1, 2],
+        r"$\omega$\n$[rad/s]$": [3, 4, 5],
+        r"$g$\n$[1]$": [6, 7, 8],
+        r"$q$\n$[rad]$": [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+        r"$\dot{q}$\n$[rad/s]$": [21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+        r"$\tau$\n$[Nm]$": [33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44],
+    }
+    pca_obs_buf_size = 10000
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.max_iterations = 2000
+
+@configclass
+class AnymalDFlatPPOFinetuneRunnerCfg(AnymalDFlatPPOPretrainRunnerCfg):
+    resume = True
+    load_run = "2025-11-04_09-59-00"
+    load_system_dynamics = True
+    system_dynamics_load_path = "logs/rsl_rl/anymal_d_flat/2025-11-04_14-31-20_pretrain_rnn/model_5000.pt"
+    system_dynamics_warmup_iterations = 500
+    run_name = "finetune"
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+        # override imagination
+        self.imagination.num_envs = 8192
+        self.imagination.num_steps_per_env = 24
+        self.imagination.max_episode_length = 256
+        self.imagination.command_resample_interval_range = [100, 120]
+        self.imagination.uncertainty_penalty_weight = -0.0
+
+
+@configclass
+class AnymalDFlatPPOVisualizeRunnerCfg(AnymalDFlatPPOPretrainRunnerCfg):
+    resume = True
+    load_system_dynamics = True
+    system_dynamics_load_path = "logs/rsl_rl/anymal_d_flat/2025-11-04_14-31-20_pretrain_rnn/model_5000.pt"
+    run_name = "visualize"

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/anymal_d/envs/anymal_d_manager_based_mbrl_env.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/anymal_d/envs/anymal_d_manager_based_mbrl_env.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# needed to import for allowing type-hinting: np.ndarray | None
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDict
+
+from mbrl.mbrl.envs import ManagerBasedMBRLEnv
+
+
+class ANYmalDManagerBasedMBRLEnv(ManagerBasedMBRLEnv):
+
+
+    def _init_additional_attributes(self):
+        self.default_joint_pos = self.scene["robot"].data.default_joint_pos[0]
+        self.default_joint_vel = self.scene["robot"].data.default_joint_vel[0]
+        self.base_velocity = None
+
+
+    def _init_additional_imagination_attributes(self):
+        self.last_air_time = torch.zeros(self.num_imagination_envs, 4, device=self.device)
+        self.current_air_time = torch.zeros(self.num_imagination_envs, 4, device=self.device)
+        self.last_contact_time = torch.zeros(self.num_imagination_envs, 4, device=self.device)
+        self.current_contact_time = torch.zeros(self.num_imagination_envs, 4, device=self.device)
+
+
+    def _reset_additional_imagination_attributes(self, env_ids):
+        self.last_air_time[env_ids] = 0.0
+        self.current_air_time[env_ids] = 0.0
+        self.last_contact_time[env_ids] = 0.0
+        self.current_contact_time[env_ids] = 0.0
+
+    
+    def get_imagination_observation(self, state_history, action_history, observation_noise=True):
+        obs_base_lin_vel = self.imagination_state_normalizer.inverse(state_history[:, -1])[:, 0:3]
+        obs_base_ang_vel = self.imagination_state_normalizer.inverse(state_history[:, -1])[:, 3:6]
+        obs_projected_gravity = self.imagination_state_normalizer.inverse(state_history[:, -1])[:, 6:9]
+        obs_joint_pos = self.imagination_state_normalizer.inverse(state_history[:, -1])[:, 9:21]
+        obs_joint_vel = self.imagination_state_normalizer.inverse(state_history[:, -1])[:, 21:33]
+        self.obs_last_action = self.imagination_action_normalizer.inverse(action_history[:, -1])
+        if observation_noise:
+            obs_base_lin_vel += 2 * (torch.rand_like(obs_base_lin_vel) - 0.5) * 0.1
+            obs_base_ang_vel += 2 * (torch.rand_like(obs_base_ang_vel) - 0.5) * 0.2
+            obs_projected_gravity += 2 * (torch.rand_like(obs_projected_gravity) - 0.5) * 0.05
+            obs_joint_pos += 2 * (torch.rand_like(obs_joint_pos) - 0.5) * 0.01
+            obs_joint_vel += 2 * (torch.rand_like(obs_joint_vel) - 0.5) * 1.5
+        obs = torch.cat([obs_base_lin_vel, obs_base_ang_vel, obs_projected_gravity, self.base_velocity, obs_joint_pos, obs_joint_vel, self.obs_last_action], dim=1)
+        obs = TensorDict({"policy": obs}, batch_size=[self.num_imagination_envs], device=self.device)
+        self.last_obs = obs
+        return obs
+    
+
+    def _parse_imagination_states(self, imagination_states_denormalized):
+        base_lin_vel = imagination_states_denormalized[:, 0:3]
+        base_ang_vel = imagination_states_denormalized[:, 3:6]
+        projected_gravity = imagination_states_denormalized[:, 6:9]
+        joint_pos = imagination_states_denormalized[:, 9:21]
+        joint_vel = imagination_states_denormalized[:, 21:33]
+        joint_torque = imagination_states_denormalized[:, 33:45]
+
+        parsed_imagination_states = {
+            "base_lin_vel": base_lin_vel,
+            "base_ang_vel": base_ang_vel,
+            "projected_gravity": projected_gravity,
+            "joint_pos": joint_pos,
+            "joint_vel": joint_vel,
+            "joint_torque": joint_torque,
+        }
+        return parsed_imagination_states
+
+    
+    def _parse_extensions(self, extensions):
+        if extensions is None:
+            return None
+        parsed_extensions = {
+        }
+        return parsed_extensions
+
+
+    def _parse_contacts(self, contacts):
+        thigh_contact = torch.sigmoid(contacts[:, 0:4]).round() if contacts is not None else None
+        foot_contact = torch.sigmoid(contacts[:, 4:8]).round() if contacts is not None else None
+        
+        parsed_contacts = {
+            "thigh_contact": thigh_contact,
+            "foot_contact": foot_contact,
+        }
+        return parsed_contacts
+    
+    
+    def _parse_terminations(self, terminations):
+        parsed_terminations = torch.sigmoid(terminations).squeeze(-1).round().bool() if terminations is not None else None
+        return parsed_terminations
+
+
+    def _compute_imagination_reward_terms(self, parsed_imagination_states, rollout_action, parsed_extensions, parsed_contacts):
+        
+        base_lin_vel = parsed_imagination_states["base_lin_vel"]
+        base_ang_vel = parsed_imagination_states["base_ang_vel"]
+        projected_gravity = parsed_imagination_states["projected_gravity"]
+        joint_pos = parsed_imagination_states["joint_pos"]
+        joint_vel = parsed_imagination_states["joint_vel"]
+        joint_torque = parsed_imagination_states["joint_torque"]
+        joint_acc = (joint_vel - self.last_obs["policy"][:, 12:24]) / self.step_dt
+        thigh_contact = parsed_contacts["thigh_contact"]
+        foot_contact = parsed_contacts["foot_contact"]
+
+        lin_vel_error = torch.sum(torch.square(self.base_velocity[:, :2] - base_lin_vel[:, :2]), dim=1)
+        ang_vel_error = torch.square(self.base_velocity[:, 2] - base_ang_vel[:, 2])
+        
+        track_lin_vel_xy_exp = torch.exp(-lin_vel_error / 0.25)
+        track_ang_vel_z_exp = torch.exp(-ang_vel_error / 0.25)
+        lin_vel_z_l2 = torch.square(base_lin_vel[:, 2])
+        ang_vel_xy_l2 = torch.sum(torch.square(base_ang_vel[:, :2]), dim=1)
+        dof_torques_l2 = torch.sum(torch.square(joint_torque), dim=1)
+        dof_acc_l2 = torch.sum(torch.square(joint_acc), dim=1)
+        action_rate_l2 = torch.sum(torch.square(self.obs_last_action - rollout_action), dim=1)
+        if foot_contact is not None:
+            first_contact = (self.current_contact_time > 0.0) * (self.current_contact_time < (self.step_dt + 1.0e-8))
+            feet_air_time = torch.sum((self.last_air_time - 0.5) * first_contact, dim=1) * (torch.norm(self.base_velocity[:, :2], dim=1) > 0.1)
+            
+            is_contact = foot_contact.bool()
+            is_first_contact = (self.current_air_time > 0) * is_contact
+            is_first_detached = (self.current_contact_time > 0) * ~is_contact
+            self.last_air_time = torch.where(
+                is_first_contact,
+                self.current_air_time + self.step_dt,
+                self.last_air_time,
+            )
+            self.current_air_time = torch.where(
+                ~is_contact, self.current_air_time + self.step_dt, 0.0
+            )
+            self.last_contact_time = torch.where(
+                is_first_detached,
+                self.current_contact_time + self.step_dt,
+                self.last_contact_time,
+            )
+            self.current_contact_time = torch.where(
+                is_contact, self.current_contact_time + self.step_dt, 0.0
+            )
+        else:
+            feet_air_time = torch.zeros(self.num_imagination_envs, device=self.device)
+        undesired_contacts = torch.sum(thigh_contact, dim=1) if thigh_contact is not None else torch.zeros(self.num_imagination_envs, device=self.device)
+        stand_still = torch.sum(torch.abs(joint_pos), dim=1) * (torch.norm(self.base_velocity, dim=1) < 0.05)
+        flat_orientation_l2 = torch.sum(torch.square(projected_gravity[:, :2]), dim=1)
+        dof_pos_limits = torch.zeros(self.num_imagination_envs, device=self.device)
+        self.imagination_reward_per_step = {
+            "track_lin_vel_xy_exp": track_lin_vel_xy_exp,
+            "track_ang_vel_z_exp": track_ang_vel_z_exp,
+            "lin_vel_z_l2": lin_vel_z_l2,
+            "ang_vel_xy_l2": ang_vel_xy_l2,
+            "dof_torques_l2": dof_torques_l2,
+            "dof_acc_l2": dof_acc_l2,
+            "action_rate_l2": action_rate_l2,
+            "feet_air_time": feet_air_time,
+            "undesired_contacts": undesired_contacts,
+            "stand_still": stand_still,
+            "flat_orientation_l2": flat_orientation_l2,
+            "dof_pos_limits": dof_pos_limits,
+        }
+        last_obs = torch.cat([base_lin_vel, base_ang_vel, projected_gravity, self.base_velocity, joint_pos, joint_vel, rollout_action], dim=1)
+        self.last_obs = TensorDict({"policy": last_obs}, batch_size=[self.num_imagination_envs], device=self.device)

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/anymal_d/envs/anymal_d_manager_based_visualize_env.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/anymal_d/envs/anymal_d_manager_based_visualize_env.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2022-2024, The Isaac Lab Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# needed to import for allowing type-hinting: np.ndarray | None
+from __future__ import annotations
+
+import torch
+
+from mbrl.mbrl.envs import ManagerBasedVisualizeEnv
+from .anymal_d_manager_based_mbrl_env import ANYmalDManagerBasedMBRLEnv
+from mbrl.mbrl.envs.mdp.events import reset_joints_to_specified, reset_root_velocity_to_specified
+from isaaclab.utils.math import quat_apply
+
+
+class ANYmalDManagerBasedVisualizeEnv(ManagerBasedVisualizeEnv, ANYmalDManagerBasedMBRLEnv):
+    
+    
+    def _reset_imagination_sim(self, parsed_imagination_states):
+        base_lin_vel = parsed_imagination_states["base_lin_vel"]
+        base_ang_vel = parsed_imagination_states["base_ang_vel"]
+        joint_pos = parsed_imagination_states["joint_pos"]
+        joint_pos += self.default_joint_pos
+        joint_vel = parsed_imagination_states["joint_vel"]
+        joint_vel += self.default_joint_vel
+        
+        root_quat_w = self.scene["robot"].data.root_quat_w[self.env_ids_imagination]
+        
+        base_lin_vel_w = quat_apply(root_quat_w, base_lin_vel)
+        base_ang_vel_w = quat_apply(root_quat_w, base_ang_vel)
+                
+        velocities = torch.cat([base_lin_vel_w, base_ang_vel_w], dim=1)
+        
+        reset_joints_to_specified(self, self.env_ids_imagination, joint_pos, joint_vel)
+        reset_root_velocity_to_specified(self, self.env_ids_imagination, velocities)

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/anymal_d/flat_env_cfg.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/anymal_d/flat_env_cfg.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+
+from isaaclab_tasks.manager_based.locomotion.velocity.config.anymal_d.rough_env_cfg import AnymalDRoughEnvCfg
+from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import ObservationsCfg, RewardsCfg
+
+from isaaclab.terrains.config.rough import ROUGH_TERRAINS_CFG  # isort: skip
+
+from mbrl.mbrl.envs.mdp.commands import UniformVelocityCommand_Visualize, SampleUniformVelocityCommand
+import mbrl.tasks.manager_based.locomotion.velocity.mdp as mdp
+
+
+@configclass
+class RewardsCfg_TRAIN(RewardsCfg):
+    stand_still = RewTerm(
+        func=mdp.joint_pos_stand_still, weight=-1.0, params={"command_name": "base_velocity", "threshold": 0.05}
+        )
+
+
+@configclass
+class AnymalDFlatEnvCfg(AnymalDRoughEnvCfg):
+    
+    rewards: RewardsCfg_TRAIN = RewardsCfg_TRAIN()
+    
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        # override rewards
+        self.rewards.flat_orientation_l2.weight = -5.0
+        self.rewards.dof_torques_l2.weight = -2.5e-5
+        self.rewards.feet_air_time.weight = 0.5
+        # change terrain to flat
+        self.scene.terrain.terrain_type = "plane"
+        self.scene.terrain.terrain_generator = None
+        # no height scan
+        self.scene.height_scanner = None
+        self.observations.policy.height_scan = None
+        # no terrain curriculum
+        self.curriculum.terrain_levels = None
+
+
+@configclass
+class AnymalDFlatEnvCfg_INIT(AnymalDFlatEnvCfg):
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+
+        # revert rewards
+        self.rewards.flat_orientation_l2.weight = 0.0
+        self.rewards.dof_torques_l2.weight = -1.0e-5
+        self.rewards.feet_air_time.weight = 0.125
+        # revert terrain
+        self.scene.terrain.terrain_type = "generator"
+        self.scene.terrain.terrain_generator = ROUGH_TERRAINS_CFG
+        self.scene.terrain.terrain_generator.curriculum = False
+        self.scene.terrain.terrain_generator.difficulty_range = (0.0, 0.0)
+        self.scene.terrain.terrain_generator.sub_terrains["pyramid_stairs"].proportion = 0.0
+        self.scene.terrain.terrain_generator.sub_terrains["pyramid_stairs_inv"].proportion = 0.0
+        self.scene.terrain.terrain_generator.sub_terrains["boxes"].proportion = 0.0
+        self.scene.terrain.terrain_generator.sub_terrains["random_rough"].proportion = 1.0
+        self.scene.terrain.terrain_generator.sub_terrains["hf_pyramid_slope"].proportion = 0.0
+        self.scene.terrain.terrain_generator.sub_terrains["hf_pyramid_slope_inv"].proportion = 0.0
+
+
+@configclass
+class ObservationsCfg_PRETRAIN(ObservationsCfg):
+
+    @configclass
+    class SystemStateCfg(ObsGroup):
+
+        # observation terms (order preserved)
+        base_lin_vel = ObsTerm(func=mdp.base_lin_vel)
+        base_ang_vel = ObsTerm(func=mdp.base_ang_vel)
+        projected_gravity = ObsTerm(func=mdp.projected_gravity)
+        joint_pos = ObsTerm(func=mdp.joint_pos_rel)
+        joint_vel = ObsTerm(func=mdp.joint_vel_rel)
+        joint_torque = ObsTerm(func=mdp.joint_effort)
+        
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+
+    @configclass
+    class SystemActionCfg(ObsGroup):
+
+        # observation terms (order preserved)
+        pred_actions = ObsTerm(func=mdp.last_action)
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+
+    @configclass
+    class SystemExtensionCfg(ObsGroup):
+
+        pass
+
+
+    @configclass
+    class SystemContactCfg(ObsGroup):
+
+        # observation terms (order preserved)
+        thigh_contact = ObsTerm(func=mdp.body_contact, params={"sensor_cfg": SceneEntityCfg("contact_forces", body_names=".*THIGH"), "threshold": 1.0})
+        foot_contact = ObsTerm(func=mdp.body_contact, params={"sensor_cfg": SceneEntityCfg("contact_forces", body_names=".*FOOT"), "threshold": 1.0})
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+
+    @configclass
+    class SystemTerminationCfg(ObsGroup):
+
+        # observation terms (order preserved)
+        base_contact = ObsTerm(func=mdp.body_contact, params={"sensor_cfg": SceneEntityCfg("contact_forces", body_names="base"), "threshold": 1.0})
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+
+    # observation groups
+    system_state: SystemStateCfg = SystemStateCfg()
+    system_action: SystemActionCfg = SystemActionCfg()
+    # system_extension: SystemExtensionCfg = SystemExtensionCfg()
+    system_contact: SystemContactCfg = SystemContactCfg()
+    system_termination: SystemTerminationCfg = SystemTerminationCfg()
+
+
+@configclass
+class AnymalDFlatEnvCfg_PRETRAIN(AnymalDFlatEnvCfg):
+    
+    # override observation terms
+    observations: ObservationsCfg_PRETRAIN = ObservationsCfg_PRETRAIN()
+    
+
+@configclass
+class AnymalDFlatEnvCfg_FINETUNE(AnymalDFlatEnvCfg_PRETRAIN):
+    def __post_init__(self) -> None:
+        # post init of parent
+        super().__post_init__()
+        self.scene.num_envs = 10
+        self.scene.env_spacing = 2.5
+        # disable randomization for play
+        self.observations.policy.enable_corruption = False
+        # override commands
+        self.commands.base_velocity.class_type = SampleUniformVelocityCommand
+
+
+@configclass
+class AnymalDFlatEnvCfg_VISUALIZE(AnymalDFlatEnvCfg_PRETRAIN):
+    
+    def __post_init__(self):
+        # post init of parent
+        super().__post_init__()
+        # make a smaller scene for visualize
+        self.scene.num_envs = 10
+        self.scene.env_spacing = 2.5
+        # disable randomization for visualize
+        self.observations.policy.enable_corruption = False
+        # remove random pushing event
+        self.events.base_external_force_torque = None
+        self.events.push_robot = None
+
+        # override commands
+        self.commands.base_velocity.class_type = UniformVelocityCommand_Visualize
+        self.commands.base_velocity.resampling_time_range = (2.0, 2.0)
+        # override randomization
+        self.events.reset_base.func = mdp.reset_root_state_uniform_visualize
+        self.events.reset_base.params = {
+            "pose_range": {"x": (-0.0, 0.0), "y": (-0.0, 0.0), "yaw": (1.57, 1.57)},
+            "velocity_range": {
+                "x": (-0.0, 0.0),
+                "y": (-0.0, 0.0),
+                "z": (-0.0, 0.0),
+                "roll": (-0.0, 0.0),
+                "pitch": (-0.0, 0.0),
+                "yaw": (-0.0, 0.0),
+            }
+        }
+        self.events.reset_robot_joints.func = mdp.reset_joints_by_scale_visualize

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/__init__.py
@@ -1,0 +1,3 @@
+"""Quadruped locomotion task configurations."""
+
+from .unitree_go2 import *  # noqa: F401, F403

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/__init__.py
@@ -1,0 +1,47 @@
+import gymnasium as gym
+
+from . import agents
+
+##
+# Register Gym environments.
+##
+
+gym.register(
+    id="Template-Isaac-Velocity-Flat-Unitree-Go2-Init-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": "mbrl.tasks.manager_based.locomotion.velocity.config.quadruped.unitree_go2.flat_env_cfg:UnitreeGo2FlatEnvCfg_INIT",
+        "rsl_rl_cfg_entry_point": "mbrl.tasks.manager_based.locomotion.velocity.config.quadruped.unitree_go2.agents.rsl_rl_ppo_cfg:UnitreeGo2FlatPPOInitRunnerCfg",
+    },
+)
+
+gym.register(
+    id="Template-Isaac-Velocity-Flat-Unitree-Go2-Pretrain-v0",
+    entry_point="mbrl.tasks.manager_based.locomotion.velocity.config.quadruped.unitree_go2.envs.unitree_go2_manager_based_mbrl_env:UnitreeGo2ManagerBasedMBRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": "mbrl.tasks.manager_based.locomotion.velocity.config.quadruped.unitree_go2.flat_env_cfg:UnitreeGo2FlatEnvCfg_PRETRAIN",
+        "rsl_rl_cfg_entry_point": "mbrl.tasks.manager_based.locomotion.velocity.config.quadruped.unitree_go2.agents.rsl_rl_ppo_cfg:UnitreeGo2FlatPPOPretrainRunnerCfg",
+    },
+)
+
+gym.register(
+    id="Template-Isaac-Velocity-Flat-Unitree-Go2-Finetune-v0",
+    entry_point="mbrl.tasks.manager_based.locomotion.velocity.config.quadruped.unitree_go2.envs.unitree_go2_manager_based_mbrl_env:UnitreeGo2ManagerBasedMBRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": "mbrl.tasks.manager_based.locomotion.velocity.config.quadruped.unitree_go2.flat_env_cfg:UnitreeGo2FlatEnvCfg_FINETUNE",
+        "rsl_rl_cfg_entry_point": "mbrl.tasks.manager_based.locomotion.velocity.config.quadruped.unitree_go2.agents.rsl_rl_ppo_cfg:UnitreeGo2FlatPPOFinetuneRunnerCfg",
+    },
+)
+
+gym.register(
+    id="Template-Isaac-Velocity-Flat-Unitree-Go2-Visualize-v0",
+    entry_point="mbrl.tasks.manager_based.locomotion.velocity.config.quadruped.unitree_go2.envs.unitree_go2_manager_based_visualize_env:UnitreeGo2ManagerBasedVisualizeEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": "mbrl.tasks.manager_based.locomotion.velocity.config.quadruped.unitree_go2.flat_env_cfg:UnitreeGo2FlatEnvCfg_VISUALIZE",
+        "rsl_rl_cfg_entry_point": "mbrl.tasks.manager_based.locomotion.velocity.config.quadruped.unitree_go2.agents.rsl_rl_ppo_cfg:UnitreeGo2FlatPPOVisualizeRunnerCfg",
+    },
+)

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/agents/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/agents/__init__.py
@@ -1,0 +1,7 @@
+from .rsl_rl_ppo_cfg import (
+    UnitreeGo2FlatPPOFinetuneRunnerCfg,
+    UnitreeGo2FlatPPOInitRunnerCfg,
+    UnitreeGo2FlatPPOPretrainRunnerCfg,
+    UnitreeGo2FlatPPORunnerCfg,
+    UnitreeGo2FlatPPOVisualizeRunnerCfg,
+)

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/agents/rsl_rl_ppo_cfg.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/agents/rsl_rl_ppo_cfg.py
@@ -1,0 +1,126 @@
+from isaaclab.utils import configclass
+from isaaclab_tasks.manager_based.locomotion.velocity.config.go2.agents.rsl_rl_ppo_cfg import UnitreeGo2FlatPPORunnerCfg
+
+from mbrl.rl.rsl_rl import RslRlMbrlImaginationCfg, RslRlMbrlPpoAlgorithmCfg, RslRlNormalizerCfg, RslRlSystemDynamicsCfg
+
+
+@configclass
+class UnitreeGo2FlatPPOInitRunnerCfg(UnitreeGo2FlatPPORunnerCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.obs_groups = {"policy": ["policy"], "critic": ["policy"]}
+
+
+@configclass
+class UnitreeGo2FlatPPOPretrainRunnerCfg(UnitreeGo2FlatPPORunnerCfg):
+    class_name: str = "MBPOOnPolicyRunner"
+
+    system_dynamics = RslRlSystemDynamicsCfg(
+        ensemble_size=5,
+        history_horizon=32,
+        architecture_config={
+            "type": "rnn",
+            "rnn_type": "gru",
+            "rnn_num_layers": 2,
+            "rnn_hidden_size": 256,
+            "state_mean_shape": [128],
+            "state_logstd_shape": [128],
+            "extension_shape": [128],
+            "contact_shape": [128],
+            "termination_shape": [128],
+        },
+        freeze_auxiliary=False,
+    )
+    imagination = RslRlMbrlImaginationCfg(
+        num_envs=0,
+        num_steps_per_env=0,
+        max_episode_length=0,
+        command_resample_interval_range=None,
+        uncertainty_penalty_weight=-0.0,
+        state_normalizer=RslRlNormalizerCfg(
+            mean=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0] + [0.0] * 36,
+            std=[0.5, 0.5, 0.1, 0.3, 0.3, 0.5, 0.02, 0.02, 0.04] + [0.2] * 12 + [2.0] * 12 + [8.0] * 12,
+        ),
+        action_normalizer=RslRlNormalizerCfg(
+            mean=[0.0] * 12,
+            std=[1.0] * 12,
+        ),
+    )
+    algorithm = RslRlMbrlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.005,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        policy_learning_rate=1.0e-3,
+        system_dynamics_learning_rate=3.0e-4,
+        system_dynamics_weight_decay=1.0e-6,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+        system_dynamics_forecast_horizon=8,
+        system_dynamics_loss_weights={
+            "state": 1.0,
+            "sequence": 2.0,
+            "bound": 1.0,
+            "kl": 0.05,
+            "extension": 1.0,
+            "contact": 2.0,
+            "termination": 2.0,
+        },
+        system_dynamics_num_mini_batches=32,
+        system_dynamics_mini_batch_size=300,
+        system_dynamics_replay_buffer_size=1500,
+        system_dynamics_num_eval_trajectories=100,
+        system_dynamics_len_eval_trajectory=400,
+        system_dynamics_eval_traj_noise_scale=[0.1, 0.2, 0.4, 0.5, 0.8],
+    )
+    run_name = "pretrain"
+    load_system_dynamics = False
+    system_dynamics_load_path = None
+    system_dynamics_warmup_iterations = 0
+    system_dynamics_num_visualizations = 4
+    system_dynamics_state_idx_dict = {
+        r"$v$\n$[m/s]$": [0, 1, 2],
+        r"$\omega$\n$[rad/s]$": [3, 4, 5],
+        r"$g$\n$[1]$": [6, 7, 8],
+        r"$q$\n$[rad]$": [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+        r"$\dot{q}$\n$[rad/s]$": [21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
+        r"$\tau$\n$[Nm]$": [33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44],
+    }
+    pca_obs_buf_size = 10000
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.obs_groups = {"policy": ["policy"], "critic": ["policy"]}
+        self.max_iterations = 2000
+
+
+@configclass
+class UnitreeGo2FlatPPOFinetuneRunnerCfg(UnitreeGo2FlatPPOPretrainRunnerCfg):
+    resume = True
+    load_run = ".*_pretrain"
+    load_system_dynamics = True
+    system_dynamics_load_path = None
+    system_dynamics_warmup_iterations = 500
+    run_name = "finetune"
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.imagination.num_envs = 8192
+        self.imagination.num_steps_per_env = 24
+        self.imagination.max_episode_length = 256
+        self.imagination.command_resample_interval_range = [100, 120]
+        self.imagination.uncertainty_penalty_weight = -0.0
+
+
+@configclass
+class UnitreeGo2FlatPPOVisualizeRunnerCfg(UnitreeGo2FlatPPOPretrainRunnerCfg):
+    resume = True
+    load_run = ".*_pretrain"
+    load_system_dynamics = True
+    system_dynamics_load_path = None
+    run_name = "visualize"

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/envs/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/envs/__init__.py
@@ -1,0 +1,2 @@
+from .unitree_go2_manager_based_mbrl_env import UnitreeGo2ManagerBasedMBRLEnv
+from .unitree_go2_manager_based_visualize_env import UnitreeGo2ManagerBasedVisualizeEnv

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/envs/unitree_go2_manager_based_mbrl_env.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/envs/unitree_go2_manager_based_mbrl_env.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import torch
+from tensordict import TensorDict
+
+from mbrl.mbrl.envs import ManagerBasedMBRLEnv
+
+
+class UnitreeGo2ManagerBasedMBRLEnv(ManagerBasedMBRLEnv):
+    def _init_additional_attributes(self):
+        self.default_joint_pos = self.scene["robot"].data.default_joint_pos[0]
+        self.default_joint_vel = self.scene["robot"].data.default_joint_vel[0]
+        self.base_velocity = None
+
+    def _init_additional_imagination_attributes(self):
+        self.last_air_time = torch.zeros(self.num_imagination_envs, 4, device=self.device)
+        self.current_air_time = torch.zeros(self.num_imagination_envs, 4, device=self.device)
+        self.last_contact_time = torch.zeros(self.num_imagination_envs, 4, device=self.device)
+        self.current_contact_time = torch.zeros(self.num_imagination_envs, 4, device=self.device)
+
+    def _reset_additional_imagination_attributes(self, env_ids):
+        self.last_air_time[env_ids] = 0.0
+        self.current_air_time[env_ids] = 0.0
+        self.last_contact_time[env_ids] = 0.0
+        self.current_contact_time[env_ids] = 0.0
+
+    def get_imagination_observation(self, state_history, action_history, observation_noise=True):
+        obs_base_lin_vel = self.imagination_state_normalizer.inverse(state_history[:, -1])[:, 0:3]
+        obs_base_ang_vel = self.imagination_state_normalizer.inverse(state_history[:, -1])[:, 3:6]
+        obs_projected_gravity = self.imagination_state_normalizer.inverse(state_history[:, -1])[:, 6:9]
+        obs_joint_pos = self.imagination_state_normalizer.inverse(state_history[:, -1])[:, 9:21]
+        obs_joint_vel = self.imagination_state_normalizer.inverse(state_history[:, -1])[:, 21:33]
+        self.obs_last_action = self.imagination_action_normalizer.inverse(action_history[:, -1])
+        if observation_noise:
+            obs_base_lin_vel += 2 * (torch.rand_like(obs_base_lin_vel) - 0.5) * 0.1
+            obs_base_ang_vel += 2 * (torch.rand_like(obs_base_ang_vel) - 0.5) * 0.2
+            obs_projected_gravity += 2 * (torch.rand_like(obs_projected_gravity) - 0.5) * 0.05
+            obs_joint_pos += 2 * (torch.rand_like(obs_joint_pos) - 0.5) * 0.01
+            obs_joint_vel += 2 * (torch.rand_like(obs_joint_vel) - 0.5) * 1.5
+        obs = torch.cat(
+            [
+                obs_base_lin_vel,
+                obs_base_ang_vel,
+                obs_projected_gravity,
+                self.base_velocity,
+                obs_joint_pos,
+                obs_joint_vel,
+                self.obs_last_action,
+            ],
+            dim=1,
+        )
+        obs = TensorDict({"policy": obs}, batch_size=[self.num_imagination_envs], device=self.device)
+        self.last_obs = obs
+        return obs
+
+    def _parse_imagination_states(self, imagination_states_denormalized):
+        base_lin_vel = imagination_states_denormalized[:, 0:3]
+        base_ang_vel = imagination_states_denormalized[:, 3:6]
+        projected_gravity = imagination_states_denormalized[:, 6:9]
+        joint_pos = imagination_states_denormalized[:, 9:21]
+        joint_vel = imagination_states_denormalized[:, 21:33]
+        joint_torque = imagination_states_denormalized[:, 33:45]
+
+        # Clamp dynamic model outputs to avoid out-of-distribution states during rollout
+        base_lin_vel[:, :2] = torch.clamp(base_lin_vel[:, :2], -3.0, 3.0)
+        base_lin_vel[:, 2] = torch.clamp(base_lin_vel[:, 2], -1.5, 1.5)
+        base_ang_vel = torch.clamp(base_ang_vel, -6.0, 6.0)
+        projected_gravity = torch.nn.functional.normalize(projected_gravity, dim=1, eps=1.0e-6)
+        joint_pos = torch.clamp(joint_pos, -1.2, 1.2)
+        joint_vel = torch.clamp(joint_vel, -30.0, 30.0)
+        joint_torque = torch.clamp(joint_torque, -80.0, 80.0)
+
+        parsed_imagination_states = {
+            "base_lin_vel": base_lin_vel,
+            "base_ang_vel": base_ang_vel,
+            "projected_gravity": projected_gravity,
+            "joint_pos": joint_pos,
+            "joint_vel": joint_vel,
+            "joint_torque": joint_torque,
+        }
+        return parsed_imagination_states
+
+    def _parse_extensions(self, extensions):
+        if extensions is None:
+            return None
+        parsed_extensions = {}
+        return parsed_extensions
+
+    def _parse_contacts(self, contacts):
+        thigh_contact = torch.sigmoid(contacts[:, 0:4]).round() if contacts is not None else None
+        foot_contact = torch.sigmoid(contacts[:, 4:8]).round() if contacts is not None else None
+        parsed_contacts = {
+            "thigh_contact": thigh_contact,
+            "foot_contact": foot_contact,
+        }
+        return parsed_contacts
+
+    def _parse_terminations(self, terminations):
+        parsed_terminations = (
+            torch.sigmoid(terminations).squeeze(-1).round().bool() if terminations is not None else None
+        )
+        return parsed_terminations
+
+    def _compute_imagination_reward_terms(self, parsed_imagination_states, rollout_action, parsed_extensions, parsed_contacts):
+        base_lin_vel = parsed_imagination_states["base_lin_vel"]
+        base_ang_vel = parsed_imagination_states["base_ang_vel"]
+        projected_gravity = parsed_imagination_states["projected_gravity"]
+        joint_pos = parsed_imagination_states["joint_pos"]
+        joint_vel = parsed_imagination_states["joint_vel"]
+        joint_torque = parsed_imagination_states["joint_torque"]
+        joint_acc = (joint_vel - self.last_obs["policy"][:, 12:24]) / self.step_dt
+        thigh_contact = parsed_contacts["thigh_contact"]
+        foot_contact = parsed_contacts["foot_contact"]
+
+        lin_vel_error = torch.sum(torch.square(self.base_velocity[:, :2] - base_lin_vel[:, :2]), dim=1)
+        ang_vel_error = torch.square(self.base_velocity[:, 2] - base_ang_vel[:, 2])
+
+        track_lin_vel_xy_exp = torch.exp(-lin_vel_error / 0.25)
+        track_ang_vel_z_exp = torch.exp(-ang_vel_error / 0.25)
+        lin_vel_z_l2 = torch.square(base_lin_vel[:, 2])
+        ang_vel_xy_l2 = torch.sum(torch.square(base_ang_vel[:, :2]), dim=1)
+        dof_torques_l2 = torch.sum(torch.square(joint_torque), dim=1)
+        dof_acc_l2 = torch.sum(torch.square(joint_acc), dim=1)
+        action_rate_l2 = torch.sum(torch.square(self.obs_last_action - rollout_action), dim=1)
+        if foot_contact is not None:
+            first_contact = (self.current_contact_time > 0.0) * (self.current_contact_time < (self.step_dt + 1.0e-8))
+            feet_air_time = torch.sum((self.last_air_time - 0.5) * first_contact, dim=1) * (
+                torch.norm(self.base_velocity[:, :2], dim=1) > 0.1
+            )
+            is_contact = foot_contact.bool()
+            is_first_contact = (self.current_air_time > 0) * is_contact
+            is_first_detached = (self.current_contact_time > 0) * ~is_contact
+            self.last_air_time = torch.where(
+                is_first_contact, self.current_air_time + self.step_dt, self.last_air_time,
+            )
+            self.current_air_time = torch.where(~is_contact, self.current_air_time + self.step_dt, 0.0)
+            self.last_contact_time = torch.where(
+                is_first_detached, self.current_contact_time + self.step_dt, self.last_contact_time,
+            )
+            self.current_contact_time = torch.where(is_contact, self.current_contact_time + self.step_dt, 0.0)
+        else:
+            feet_air_time = torch.zeros(self.num_imagination_envs, device=self.device)
+        undesired_contacts = (
+            torch.sum(thigh_contact, dim=1)
+            if thigh_contact is not None
+            else torch.zeros(self.num_imagination_envs, device=self.device)
+        )
+        joint_pos_posture = torch.sum(torch.abs(joint_pos), dim=1)
+        stand_still = torch.sum(torch.abs(joint_pos), dim=1) * (torch.norm(self.base_velocity, dim=1) < 0.05)
+        flat_orientation_l2 = torch.sum(torch.square(projected_gravity[:, :2]), dim=1)
+        dof_pos_limits = torch.zeros(self.num_imagination_envs, device=self.device)
+        self.imagination_reward_per_step = {
+            "track_lin_vel_xy_exp": track_lin_vel_xy_exp,
+            "track_ang_vel_z_exp": track_ang_vel_z_exp,
+            "lin_vel_z_l2": lin_vel_z_l2,
+            "ang_vel_xy_l2": ang_vel_xy_l2,
+            "dof_torques_l2": dof_torques_l2,
+            "dof_acc_l2": dof_acc_l2,
+            "action_rate_l2": action_rate_l2,
+            "feet_air_time": feet_air_time,
+            "undesired_contacts": undesired_contacts,
+            "joint_pos_posture": joint_pos_posture,
+            "stand_still": stand_still,
+            "flat_orientation_l2": flat_orientation_l2,
+            "dof_pos_limits": dof_pos_limits,
+        }
+        last_obs = torch.cat(
+            [base_lin_vel, base_ang_vel, projected_gravity, self.base_velocity, joint_pos, joint_vel, rollout_action],
+            dim=1,
+        )
+        self.last_obs = TensorDict({"policy": last_obs}, batch_size=[self.num_imagination_envs], device=self.device)

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/envs/unitree_go2_manager_based_visualize_env.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/envs/unitree_go2_manager_based_visualize_env.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import torch
+
+from isaaclab.utils.math import quat_apply
+
+from mbrl.mbrl.envs import ManagerBasedVisualizeEnv
+from mbrl.mbrl.envs.mdp.events import reset_joints_to_specified, reset_root_velocity_to_specified
+
+from .unitree_go2_manager_based_mbrl_env import UnitreeGo2ManagerBasedMBRLEnv
+
+
+class UnitreeGo2ManagerBasedVisualizeEnv(ManagerBasedVisualizeEnv, UnitreeGo2ManagerBasedMBRLEnv):
+    def _reset_imagination_sim(self, parsed_imagination_states):
+        base_lin_vel = parsed_imagination_states["base_lin_vel"]
+        base_ang_vel = parsed_imagination_states["base_ang_vel"]
+        joint_pos = parsed_imagination_states["joint_pos"]
+        joint_pos += self.default_joint_pos
+        joint_vel = parsed_imagination_states["joint_vel"]
+        joint_vel += self.default_joint_vel
+
+        root_quat_w = self.scene["robot"].data.root_quat_w[self.env_ids_imagination]
+
+        base_lin_vel_w = quat_apply(root_quat_w, base_lin_vel)
+        base_ang_vel_w = quat_apply(root_quat_w, base_ang_vel)
+
+        velocities = torch.cat([base_lin_vel_w, base_ang_vel_w], dim=1)
+
+        reset_joints_to_specified(self, self.env_ids_imagination, joint_pos, joint_vel)
+        reset_root_velocity_to_specified(self, self.env_ids_imagination, velocities)

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/flat_env_cfg.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/flat_env_cfg.py
@@ -1,0 +1,173 @@
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import ObservationsCfg, RewardsCfg
+
+import mbrl.tasks.manager_based.locomotion.velocity.mdp as mdp
+from mbrl.mbrl.envs.mdp.commands import SampleUniformVelocityCommand, UniformVelocityCommand_Visualize
+
+from .rough_env_cfg import UnitreeGo2RoughEnvCfg
+
+from isaaclab.terrains.config.rough import ROUGH_TERRAINS_CFG  # isort: skip
+
+
+@configclass
+class RewardsCfg_TRAIN(RewardsCfg):
+    stand_still = RewTerm(
+        func=mdp.joint_pos_stand_still,
+        weight=-1.0,
+        params={"command_name": "base_velocity", "threshold": 0.05},
+    )
+    joint_pos_posture = RewTerm(
+        func=mdp.joint_pos_deviation_l1,
+        weight=-0.12,
+    )
+
+
+@configclass
+class UnitreeGo2FlatEnvCfg(UnitreeGo2RoughEnvCfg):
+    rewards: RewardsCfg_TRAIN = RewardsCfg_TRAIN()
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.rewards.flat_orientation_l2.weight = -7.5
+        self.rewards.dof_torques_l2.weight = -2.5e-5
+        self.rewards.feet_air_time.weight = 0.95
+        self.scene.terrain.terrain_type = "plane"
+        self.scene.terrain.terrain_generator = None
+        self.scene.height_scanner = None
+        self.observations.policy.height_scan = None
+        self.curriculum.terrain_levels = None
+
+
+@configclass
+class UnitreeGo2FlatEnvCfg_INIT(UnitreeGo2FlatEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.rewards.flat_orientation_l2.weight = 0.0
+        self.rewards.dof_torques_l2.weight = -1.0e-5
+        self.rewards.feet_air_time.weight = 0.125
+        self.scene.terrain.terrain_type = "generator"
+        self.scene.terrain.terrain_generator = ROUGH_TERRAINS_CFG
+        self.scene.terrain.terrain_generator.curriculum = False
+        self.scene.terrain.terrain_generator.difficulty_range = (0.0, 0.0)
+        self.scene.terrain.terrain_generator.sub_terrains["pyramid_stairs"].proportion = 0.0
+        self.scene.terrain.terrain_generator.sub_terrains["pyramid_stairs_inv"].proportion = 0.0
+        self.scene.terrain.terrain_generator.sub_terrains["boxes"].proportion = 0.0
+        self.scene.terrain.terrain_generator.sub_terrains["random_rough"].proportion = 1.0
+        self.scene.terrain.terrain_generator.sub_terrains["hf_pyramid_slope"].proportion = 0.0
+        self.scene.terrain.terrain_generator.sub_terrains["hf_pyramid_slope_inv"].proportion = 0.0
+
+
+@configclass
+class ObservationsCfg_PRETRAIN(ObservationsCfg):
+    @configclass
+    class SystemStateCfg(ObsGroup):
+        base_lin_vel = ObsTerm(func=mdp.base_lin_vel)
+        base_ang_vel = ObsTerm(func=mdp.base_ang_vel)
+        projected_gravity = ObsTerm(func=mdp.projected_gravity)
+        joint_pos = ObsTerm(func=mdp.joint_pos_rel)
+        joint_vel = ObsTerm(func=mdp.joint_vel_rel)
+        joint_torque = ObsTerm(func=mdp.joint_effort)
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+    @configclass
+    class SystemActionCfg(ObsGroup):
+        pred_actions = ObsTerm(func=mdp.last_action)
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+    @configclass
+    class SystemExtensionCfg(ObsGroup):
+        pass
+
+    @configclass
+    class SystemContactCfg(ObsGroup):
+        thigh_contact = ObsTerm(
+            func=mdp.body_contact,
+            params={
+                "sensor_cfg": SceneEntityCfg("contact_forces", body_names=".*_thigh"),
+                "threshold": 1.0,
+            },
+        )
+        foot_contact = ObsTerm(
+            func=mdp.body_contact,
+            params={
+                "sensor_cfg": SceneEntityCfg("contact_forces", body_names=".*_foot"),
+                "threshold": 1.0,
+            },
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+    @configclass
+    class SystemTerminationCfg(ObsGroup):
+        base_contact = ObsTerm(
+            func=mdp.body_contact,
+            params={
+                "sensor_cfg": SceneEntityCfg("contact_forces", body_names="base"),
+                "threshold": 1.0,
+            },
+        )
+
+        def __post_init__(self):
+            self.enable_corruption = False
+            self.concatenate_terms = True
+
+    system_state: SystemStateCfg = SystemStateCfg()
+    system_action: SystemActionCfg = SystemActionCfg()
+    system_contact: SystemContactCfg = SystemContactCfg()
+    system_termination: SystemTerminationCfg = SystemTerminationCfg()
+
+
+@configclass
+class UnitreeGo2FlatEnvCfg_PRETRAIN(UnitreeGo2FlatEnvCfg):
+    observations: ObservationsCfg_PRETRAIN = ObservationsCfg_PRETRAIN()
+
+
+@configclass
+class UnitreeGo2FlatEnvCfg_FINETUNE(UnitreeGo2FlatEnvCfg_PRETRAIN):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.scene.num_envs = 10
+        self.scene.env_spacing = 2.5
+        self.observations.policy.enable_corruption = False
+        self.commands.base_velocity.class_type = SampleUniformVelocityCommand
+
+
+@configclass
+class UnitreeGo2FlatEnvCfg_VISUALIZE(UnitreeGo2FlatEnvCfg_PRETRAIN):
+    def __post_init__(self):
+        super().__post_init__()
+        self.scene.num_envs = 10
+        self.scene.env_spacing = 2.5
+        self.observations.policy.enable_corruption = False
+        self.events.base_external_force_torque = None
+        self.events.push_robot = None
+
+        self.commands.base_velocity.class_type = UniformVelocityCommand_Visualize
+        self.commands.base_velocity.resampling_time_range = (2.0, 2.0)
+        self.events.reset_base.func = mdp.reset_root_state_uniform_visualize
+        self.events.reset_base.params = {
+            "pose_range": {"x": (-0.0, 0.0), "y": (-0.0, 0.0), "yaw": (1.57, 1.57)},
+            "velocity_range": {
+                "x": (-0.0, 0.0),
+                "y": (-0.0, 0.0),
+                "z": (-0.0, 0.0),
+                "roll": (-0.0, 0.0),
+                "pitch": (-0.0, 0.0),
+                "yaw": (-0.0, 0.0),
+            },
+        }
+        self.events.reset_robot_joints.func = mdp.reset_joints_by_scale_visualize

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/rough_env_cfg.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/config/quadruped/unitree_go2/rough_env_cfg.py
@@ -1,0 +1,7 @@
+from isaaclab_tasks.manager_based.locomotion.velocity.config.go2.rough_env_cfg import (
+    UnitreeGo2RoughEnvCfg as _UnitreeGo2RoughEnvCfg,
+)
+
+
+class UnitreeGo2RoughEnvCfg(_UnitreeGo2RoughEnvCfg):
+    pass

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/mdp/__init__.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/mdp/__init__.py
@@ -1,0 +1,7 @@
+"""This sub-module contains the functions that are specific to the locomotion environments."""
+
+from mbrl.mbrl.envs.mdp import *  # noqa: F401, F403
+from isaaclab_tasks.manager_based.locomotion.velocity.mdp import *  # noqa: F401, F403
+
+from .observations import *  # noqa: F401, F403
+from .rewards import *  # noqa: F401, F403

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/mdp/observations.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/mdp/observations.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import torch
+from typing import TYPE_CHECKING
+
+import isaaclab.utils.math as math_utils
+from isaaclab.assets import Articulation, RigidObject
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers.manager_base import ManagerTermBase
+from isaaclab.managers.manager_term_cfg import ObservationTermCfg
+from isaaclab.sensors import Camera, Imu, RayCaster, RayCasterCamera, TiledCamera
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedEnv, ManagerBasedRLEnv
+
+from isaaclab.envs.utils.io_descriptors import (
+    generic_io_descriptor,
+    record_body_names,
+    record_dtype,
+    record_joint_names,
+    record_joint_pos_offsets,
+    record_joint_vel_offsets,
+    record_shape,
+)
+
+
+@generic_io_descriptor(
+    observation_type="RootState", on_inspect=[record_shape, record_dtype]
+)
+def over_orientation(env: ManagerBasedEnv, limit_angle: float, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")) -> torch.Tensor:
+    """Bad orientation.
+    
+    Note: This function is typically used as a termination condition.
+    
+    Args:
+        env: The environment.
+        limit_angle: The limit angle in radians.
+        asset_cfg: The RigidObject associated with this observation.
+
+    Returns:
+        A boolean tensor indicating whether the orientation is bad.
+    """
+    # extract the used quantities (to enable type-hinting)
+    asset: RigidObject = env.scene[asset_cfg.name]
+    return torch.acos(-asset.data.projected_gravity_b[:, 2]).abs().unsqueeze(-1) > limit_angle
+
+
+@generic_io_descriptor(observation_type="BodyState", on_inspect=[record_shape, record_dtype, record_body_names])
+def body_height_w(
+    env: ManagerBasedEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """The height of bodies of an Articulation.
+
+    Note: Only the bodies configured in :attr:`asset_cfg.body_ids` will have their poses returned.
+
+    Args:
+        env: The environment.
+        asset_cfg: The Articulation associated with this observation.
+
+    Returns:
+        The height of the bodies of the Articulation. Output is stacked horizontally per body.
+    """
+    # extract the used quantities (to enable type-hinting)
+    asset: Articulation = env.scene[asset_cfg.name]
+    return asset.data.body_pos_w[:, asset_cfg.body_ids, 2]
+
+
+@generic_io_descriptor(observation_type="BodyState", on_inspect=[record_shape, record_dtype, record_body_names])
+def body_lin_vel_w_norm(
+    env: ManagerBasedEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """The linear velocity of bodies of an Articulation.
+
+    Note: Only the bodies configured in :attr:`asset_cfg.body_ids` will have their poses returned.
+
+    Args:
+        env: The environment.
+        asset_cfg: The Articulation associated with this observation.
+
+    Returns:
+        The linear velocity of bodies of an Articulation. Output is stacked horizontally per body.
+    """
+    # extract the used quantities (to enable type-hinting)
+    asset: Articulation = env.scene[asset_cfg.name]
+    return torch.norm(asset.data.body_lin_vel_w[:, asset_cfg.body_ids, :2], dim=2)

--- a/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/mdp/rewards.py
+++ b/robotic_world_model/source/mbrl/mbrl/tasks/manager_based/locomotion/velocity/mdp/rewards.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import torch
+from typing import TYPE_CHECKING
+
+from isaaclab.managers import SceneEntityCfg
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+def joint_pos_stand_still(
+    env: ManagerBasedRLEnv, command_name: str, threshold: float, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")
+) -> torch.Tensor:
+    """Penalize joint position error from default on the articulation."""
+    # extract the used quantities (to enable type-hinting)
+    asset = env.scene[asset_cfg.name]
+    # compute out of limits constraints
+    command = torch.norm(env.command_manager.get_command(command_name), dim=1)
+    return torch.sum(torch.abs(asset.data.joint_pos - asset.data.default_joint_pos), dim=1) * (command < threshold)
+
+
+def foot_clearance(
+    env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg, target_height: float, std: float, tanh_mult: float
+) -> torch.Tensor:
+    """Reward the swinging feet for clearing a specified height off the ground"""
+    asset = env.scene[asset_cfg.name]
+    foot_z_target_error = torch.square(asset.data.body_pos_w[:, asset_cfg.body_ids, 2] - target_height)
+    foot_velocity_tanh = torch.tanh(tanh_mult * torch.norm(asset.data.body_lin_vel_w[:, asset_cfg.body_ids, :2], dim=2))
+    return torch.exp(-torch.sum(foot_z_target_error * foot_velocity_tanh, dim=1) / std)

--- a/robotic_world_model/source/mbrl/mbrl/ui_extension_example.py
+++ b/robotic_world_model/source/mbrl/mbrl/ui_extension_example.py
@@ -1,0 +1,41 @@
+import omni.ext
+
+
+# Functions and vars are available to other extension as usual in python: `example.python_ext.some_public_function(x)`
+def some_public_function(x: int):
+    print("[mbrl] some_public_function was called with x: ", x)
+    return x**x
+
+
+# Any class derived from `omni.ext.IExt` in top level module (defined in `python.modules` of `extension.toml`) will be
+# instantiated when extension gets enabled and `on_startup(ext_id)` will be called. Later when extension gets disabled
+# on_shutdown() is called.
+class ExampleExtension(omni.ext.IExt):
+    # ext_id is current extension id. It can be used with extension manager to query additional information, like where
+    # this extension is located on filesystem.
+    def on_startup(self, ext_id):
+        print("[mbrl] startup")
+
+        self._count = 0
+
+        self._window = omni.ui.Window("My Window", width=300, height=300)
+        with self._window.frame:
+            with omni.ui.VStack():
+                label = omni.ui.Label("")
+
+                def on_click():
+                    self._count += 1
+                    label.text = f"count: {self._count}"
+
+                def on_reset():
+                    self._count = 0
+                    label.text = "empty"
+
+                on_reset()
+
+                with omni.ui.HStack():
+                    omni.ui.Button("Add", clicked_fn=on_click)
+                    omni.ui.Button("Reset", clicked_fn=on_reset)
+
+    def on_shutdown(self):
+        print("[mbrl] shutdown")

--- a/robotic_world_model/source/mbrl/pyproject.toml
+++ b/robotic_world_model/source/mbrl/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "toml"]
+build-backend = "setuptools.build_meta"

--- a/robotic_world_model/source/mbrl/setup.py
+++ b/robotic_world_model/source/mbrl/setup.py
@@ -1,0 +1,39 @@
+"""Installation script for the 'mbrl' python package."""
+
+import os
+import toml
+
+from setuptools import setup
+
+# Obtain the extension data from the extension.toml file
+EXTENSION_PATH = os.path.dirname(os.path.realpath(__file__))
+# Read the extension.toml file
+EXTENSION_TOML_DATA = toml.load(os.path.join(EXTENSION_PATH, "config", "extension.toml"))
+
+# Minimum dependencies required prior to installation
+INSTALL_REQUIRES = [
+    # NOTE: Add dependencies
+    "psutil",
+]
+
+# Installation operation
+setup(
+    name="mbrl",
+    packages=["mbrl"],
+    author=EXTENSION_TOML_DATA["package"]["author"],
+    maintainer=EXTENSION_TOML_DATA["package"]["maintainer"],
+    url=EXTENSION_TOML_DATA["package"]["repository"],
+    version=EXTENSION_TOML_DATA["package"]["version"],
+    description=EXTENSION_TOML_DATA["package"]["description"],
+    keywords=EXTENSION_TOML_DATA["package"]["keywords"],
+    install_requires=INSTALL_REQUIRES,
+    license="Apache 2.0",
+    include_package_data=True,
+    python_requires=">=3.10",
+    classifiers=[
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3.10",
+        "Isaac Sim :: 4.5.0",
+    ],
+    zip_safe=False,
+)

--- a/run_uncertainty_viz.py
+++ b/run_uncertainty_viz.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""
+run_uncertainty_viz.py  —  Live uncertainty visualization for SystemDynamicsEnsemble.
+
+Standalone script: reconstructs the model directly from the checkpoint state_dict
+(no Isaac Lab / rsl_rl installation required — only torch, numpy, matplotlib).
+
+Architecture (reverse-engineered from checkpoint):
+  - Shared GRU backbone   state_base.memory.rnn        input=57 (45+12), hidden=256, layers=2
+  - E independent heads   state_heads.{0..E-1}         GRU-out(256) → MLP → (mean 45, logstd 45)
+  - Auxiliary backbone    auxiliary_base.memory.rnn     same GRU structure (contact / termination)
+  - E auxiliary heads     auxiliary_heads.{0..E-1}      → contact(8), termination(1)
+
+Usage:
+    python run_uncertainty_viz.py \
+        --checkpoint checkpoints_paws/model_2000_pretrain.pt \
+        --data       utils_paws/walk_spot2.npz \
+        [--device cpu] [--pause 0.05] [--update_every 10]
+"""
+
+from __future__ import annotations
+import argparse, sys
+import numpy as np
+import torch
+import torch.nn as nn
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+
+# ── Go2 normalization constants (from Go2FlatConfig) ─────────────────────────
+_STATE_MEAN = [0.0, 0.0, 0.0,  0.0, 0.0, 0.0,  0.0, 0.0, -1.0] + [0.0] * 36
+_STATE_STD  = ([0.5, 0.5, 0.1,  0.3, 0.3, 0.5,  0.02, 0.02, 0.04]
+               + [0.2] * 12 + [2.0] * 12 + [8.0] * 12)
+_ACT_MEAN   = [0.0] * 12
+_ACT_STD    = [1.0] * 12
+
+_DIM_LABELS = (
+    ["vx", "vy", "vz", "wx", "wy", "wz", "gx", "gy", "gz"]
+    + [f"q{i}"  for i in range(12)]
+    + [f"dq{i}" for i in range(12)]
+    + [f"τ{i}"  for i in range(12)]
+)
+
+
+# ── standalone model ─────────────────────────────────────────────────────────
+
+class _StateHead(nn.Module):
+    """Single ensemble head: GRU-output(256) → mean(D) + clamped logstd(D)."""
+
+    def __init__(self, hidden: int, state_dim: int, mlp_hidden: int):
+        super().__init__()
+        self.mean_net   = nn.Sequential(nn.Linear(hidden, mlp_hidden), nn.ELU(),
+                                        nn.Linear(mlp_hidden, state_dim))
+        self.logstd_net = nn.Sequential(nn.Linear(hidden, mlp_hidden), nn.ELU(),
+                                        nn.Linear(mlp_hidden, state_dim))
+        # learnable logstd clamp: logstd ∈ [min, min + softplus(delta)]
+        self.register_parameter("state_min_logstd",
+                                nn.Parameter(torch.zeros(1, state_dim)))
+        self.register_parameter("state_log_delta_logstd",
+                                nn.Parameter(torch.zeros(1, state_dim)))
+
+    def forward(self, h: torch.Tensor):
+        """h: (B, hidden) → mean (B,D), std (B,D)"""
+        mean       = self.mean_net(h)
+        raw_logstd = self.logstd_net(h)
+        lo  = self.state_min_logstd
+        hi  = lo + nn.functional.softplus(self.state_log_delta_logstd)
+        logstd = lo + (hi - lo) * torch.sigmoid(raw_logstd)
+        return mean, torch.exp(logstd)
+
+
+class EnsembleWorldModel(nn.Module):
+    """
+    Lightweight re-implementation of SystemDynamicsEnsemble.
+
+    Shared GRU backbone + E independent state prediction heads.
+    Hidden state is maintained between forward() calls; call reset() to clear it.
+    """
+
+    def __init__(self, state_dim: int, action_dim: int, E: int,
+                 rnn_hidden: int, rnn_layers: int, mlp_hidden: int,
+                 device: torch.device):
+        super().__init__()
+        self.state_dim  = state_dim
+        self.action_dim = action_dim
+        self.E          = E
+        self.rnn_hidden = rnn_hidden
+        self.rnn_layers = rnn_layers
+        self.device     = device
+
+        input_dim = state_dim + action_dim   # 57
+        self.rnn = nn.GRU(input_size=input_dim, hidden_size=rnn_hidden,
+                          num_layers=rnn_layers, batch_first=True)
+        self.heads = nn.ModuleList(
+            [_StateHead(rnn_hidden, state_dim, mlp_hidden) for _ in range(E)]
+        )
+        self._hidden: torch.Tensor | None = None   # (layers, B, H)
+
+    # ── weight loading from checkpoint ───────────────────────────────────────
+    @classmethod
+    def from_checkpoint(cls, ckpt_path: str, device: torch.device) -> "EnsembleWorldModel":
+        ckpt = torch.load(ckpt_path, map_location=device, weights_only=False)
+        sd   = ckpt.get("system_dynamics_state_dict", ckpt) if isinstance(ckpt, dict) else ckpt
+
+        # infer E from state_heads.N keys
+        head_ids = {int(k.split(".")[1]) for k in sd if k.startswith("state_heads.")}
+        E = max(head_ids) + 1 if head_ids else 1
+
+        # infer rnn_hidden from weight_ih_l0 shape: (3*H, input)
+        rnn_hidden = sd["state_base.memory.rnn.weight_ih_l0"].shape[0] // 3
+        rnn_layers = sum(1 for k in sd if k.startswith("state_base.memory.rnn.weight_ih_l"))
+        state_dim  = sd["state_heads.0.state_mean_layers.2.weight"].shape[0]
+        mlp_hidden = sd["state_heads.0.state_mean_layers.0.weight"].shape[0]
+
+        print(f"[model] E={E}  state_dim={state_dim}  rnn_hidden={rnn_hidden}"
+              f"  rnn_layers={rnn_layers}  mlp_hidden={mlp_hidden}")
+
+        model = cls(state_dim, 12, E, rnn_hidden, rnn_layers, mlp_hidden, device)
+
+        # map checkpoint keys to our module
+        remap: dict[str, str] = {}
+        for k in sd:
+            if k.startswith("state_base.memory.rnn."):
+                remap[k] = k.replace("state_base.memory.rnn.", "rnn.")
+            elif k.startswith("state_heads."):
+                # state_heads.e.state_mean_layers.L.X  → heads.e.mean_net.L.X
+                # state_heads.e.state_logstd_layers.L.X → heads.e.logstd_net.L.X
+                # state_heads.e.state_min_logstd        → heads.e.state_min_logstd
+                # state_heads.e.state_log_delta_logstd  → heads.e.state_log_delta_logstd
+                parts = k.split(".")
+                e = parts[1]
+                rest = ".".join(parts[2:])
+                rest = rest.replace("state_mean_layers.", "mean_net.")
+                rest = rest.replace("state_logstd_layers.", "logstd_net.")
+                remap[k] = f"heads.{e}.{rest}"
+
+        new_sd = {remap[k]: v for k, v in sd.items() if k in remap}
+        missing = set(model.state_dict().keys()) - set(new_sd.keys())
+        if missing:
+            print(f"[model] WARNING: {len(missing)} keys not loaded: {list(missing)[:4]}")
+        model.load_state_dict(new_sd, strict=False)
+        model.eval().to(device)
+        return model
+
+    # ── stateful inference ───────────────────────────────────────────────────
+    def reset(self, batch_size: int | None = None):
+        """Clear GRU hidden state (call before a new trajectory)."""
+        self._hidden = None
+
+    @torch.no_grad()
+    def forward(self, states: torch.Tensor, actions: torch.Tensor) -> tuple:
+        """
+        Args:
+            states  : (B, T, state_dim)  normalized
+            actions : (B, T, action_dim) normalized
+        Returns:
+            means   : (E, B, state_dim)
+            stds    : (E, B, state_dim)
+        After the call the GRU hidden state is updated for the next step.
+        """
+        x = torch.cat([states, actions], dim=-1)   # (B, T, 57)
+        out, self._hidden = self.rnn(x, self._hidden)
+        h_last = out[:, -1, :]                      # (B, hidden)
+
+        means_list, stds_list = [], []
+        for head in self.heads:
+            mu, sigma = head(h_last)
+            means_list.append(mu)
+            stds_list.append(sigma)
+
+        means = torch.stack(means_list, dim=0)   # (E, B, D)
+        stds  = torch.stack(stds_list,  dim=0)   # (E, B, D)
+        return means, stds
+
+
+# ── rollout ───────────────────────────────────────────────────────────────────
+
+def run_rollout(
+    model: EnsembleWorldModel,
+    ns: torch.Tensor, na: torch.Tensor,
+    H: int = 32,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Single stateful rollout — B=1 (sequential data, no batching needed).
+
+    Step 0  : feed full H-step window to warm up the GRU
+    Steps 1+: feed 1 step at a time (hidden state carries context)
+
+    Returns:
+        head_mu  : (E, T', D)   per-head predicted next-state (normalized)
+        head_sig : (E, T', D)   per-head aleatoric std
+        epi_unc  : (T',)        epistemic unc  = std across heads, summed over dims
+        ale_unc  : (T',)        aleatoric unc  = mean of per-head stds, summed over dims
+    where T' = T - H.
+    """
+    T  = ns.shape[0]
+    T_ = T - H
+    E  = model.E
+
+    mu_buf  = np.zeros((T_, E, model.state_dim), dtype=np.float32)
+    sig_buf = np.zeros((T_, E, model.state_dim), dtype=np.float32)
+
+    model.reset()
+
+    # warmup: full window, B=1
+    s_w = ns[:H].unsqueeze(0)   # (1, H, 45)
+    a_w = na[:H].unsqueeze(0)   # (1, H, 12)
+    mu, sig = model(s_w, a_w)   # (E, 1, D)
+    mu_buf[0]  = mu[:,  0, :].cpu().numpy()
+    sig_buf[0] = sig[:, 0, :].cpu().numpy()
+
+    for i in range(1, T_):
+        t = H + i
+        s_step = ns[t].view(1, 1, -1)
+        a_step = na[t].view(1, 1, -1)
+        mu, sig = model(s_step, a_step)   # (E, 1, D)
+        mu_buf[i]  = mu[:,  0, :].cpu().numpy()
+        sig_buf[i] = sig[:, 0, :].cpu().numpy()
+
+        if i % 500 == 0:
+            print(f"  step {i}/{T_}")
+
+    # (E, T', D) -> transpose to (E, T', D) — already correct
+    head_mu  = mu_buf.transpose(1, 0, 2)   # (E, T', D)  wait, mu_buf is (T',E,D)
+    head_sig = sig_buf.transpose(1, 0, 2)  # (E, T', D)
+
+    # epistemic: std across E heads, summed over D
+    epi_unc = head_mu.std(axis=0).sum(axis=-1)          # (T',)
+    # aleatoric: mean of per-head stds, summed over D
+    ale_unc = head_sig.mean(axis=0).sum(axis=-1)        # (T',)
+
+    return head_mu, head_sig, epi_unc, ale_unc
+
+
+# ── figure ────────────────────────────────────────────────────────────────────
+
+def make_figure(E: int):
+    fig = plt.figure(figsize=(20, 12))
+    fig.suptitle("SystemDynamicsEnsemble — Go2 Uncertainty", fontsize=13)
+    gs = gridspec.GridSpec(3, 6, figure=fig, hspace=0.50, wspace=0.40)
+
+    ax_hist_epi = fig.add_subplot(gs[0, 0:2])
+    ax_hist_ale = fig.add_subplot(gs[0, 2:4])
+    ax_ts       = fig.add_subplot(gs[0, 4:6])
+    ax_mu       = [fig.add_subplot(gs[1, d]) for d in range(6)]
+    ax_sig      = [fig.add_subplot(gs[2, d]) for d in range(6)]
+
+    for ax in [ax_hist_epi, ax_hist_ale, ax_ts, *ax_mu, *ax_sig]:
+        ax.tick_params(labelsize=6)
+
+    plt.ion()
+    plt.show()
+    return fig, ax_hist_epi, ax_hist_ale, ax_ts, ax_mu, ax_sig
+
+
+def update_figure(fig, ax_he, ax_ha, ax_ts,
+                  ax_mu, ax_sig,
+                  t: int,
+                  head_mu: np.ndarray, head_sig: np.ndarray,
+                  epi_unc: np.ndarray, ale_unc: np.ndarray,
+                  palette, E: int):
+    ts = np.arange(t + 1)
+
+    # ── row 0 ────────────────────────────────────────────────────────────
+    ax_he.cla()
+    ax_he.hist(epi_unc[:t+1], bins=40, color="steelblue", alpha=0.85, edgecolor="none")
+    ax_he.set_xlabel("epistemic unc.", fontsize=7)
+    ax_he.set_title("Epistemic unc. (history)", fontsize=9)
+
+    ax_ha.cla()
+    ax_ha.hist(ale_unc[:t+1], bins=40, color="tomato", alpha=0.85, edgecolor="none")
+    ax_ha.set_xlabel("aleatoric unc.", fontsize=7)
+    ax_ha.set_title("Aleatoric unc. (history)", fontsize=9)
+
+    ax_ts.cla()
+    ax_ts.plot(ts, epi_unc[:t+1], color="steelblue", lw=1.0, label="epistemic")
+    ax_ts.plot(ts, ale_unc[:t+1], color="tomato",    lw=1.0, label="aleatoric")
+    ax_ts.set_xlabel("step", fontsize=7)
+    ax_ts.legend(fontsize=7)
+    ax_ts.set_title("Uncertainty over rollout", fontsize=9)
+
+    # ── rows 1-2: per-head per-dim ────────────────────────────────────────
+    for d in range(6):
+        ax_mu[d].cla()
+        ax_sig[d].cla()
+        ax_mu[d].set_title(f"μ  {_DIM_LABELS[d]}", fontsize=8)
+        ax_sig[d].set_title(f"σ  {_DIM_LABELS[d]}", fontsize=8)
+        ax_mu[d].set_xlabel("step", fontsize=6)
+        ax_sig[d].set_xlabel("step", fontsize=6)
+        for e in range(E):
+            c = palette[e]
+            ax_mu[d].plot( ts, head_mu[e,  :t+1, d], color=c, lw=0.8, alpha=0.9,
+                           label=f"h{e}" if d == 0 else None)
+            ax_sig[d].plot(ts, head_sig[e, :t+1, d], color=c, lw=0.8, alpha=0.9)
+        if d == 0:
+            ax_mu[d].legend(fontsize=6, ncol=3, loc="best")
+
+    fig.canvas.draw()
+    fig.canvas.flush_events()
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--checkpoint",   required=True, help="path to .pt checkpoint")
+    ap.add_argument("--data",         required=True, help="path to walk_spot2.npz")
+    ap.add_argument("--device",       default="cpu")
+    ap.add_argument("--pause",        type=float, default=0.05)
+    ap.add_argument("--update_every", type=int,   default=10)
+    ap.add_argument("--history",      type=int,   default=32,
+                    help="GRU warm-up window (default: 32)")
+    args = ap.parse_args()
+
+    device = torch.device(args.device)
+    H      = args.history
+
+    # ── data ─────────────────────────────────────────────────────────────
+    print(f"[data] {args.data}")
+    npz = np.load(args.data)
+    raw_obs     = torch.tensor(npz["obs"],     dtype=torch.float32, device=device)
+    raw_actions = torch.tensor(npz["actions"], dtype=torch.float32, device=device)
+    T = raw_obs.shape[0]
+    print(f"[data] {T} frames  obs={tuple(raw_obs.shape)}  actions={tuple(raw_actions.shape)}")
+
+    # ── model ─────────────────────────────────────────────────────────────
+    model = EnsembleWorldModel.from_checkpoint(args.checkpoint, device)
+    E = model.E
+
+    # ── normalize ─────────────────────────────────────────────────────────
+    s_mean = torch.tensor(_STATE_MEAN, dtype=torch.float32, device=device)
+    s_std  = torch.tensor(_STATE_STD,  dtype=torch.float32, device=device)
+    a_mean = torch.tensor(_ACT_MEAN,   dtype=torch.float32, device=device)
+    a_std  = torch.tensor(_ACT_STD,    dtype=torch.float32, device=device)
+    ns = (raw_obs     - s_mean) / s_std
+    na = (raw_actions - a_mean) / a_std
+
+    T_ = T - H
+    if T_ <= 0:
+        sys.exit(f"Data has {T} frames but --history={H}; need T > H.")
+
+    # ── rollout ───────────────────────────────────────────────────────────
+    print(f"[rollout] {T_} steps with E={E} heads ...")
+    head_mu, head_sig, epi_unc, ale_unc = run_rollout(model, ns, na, H)
+    # head_mu/head_sig: (E, T', 45)
+    print(f"[unc] epistemic  min={epi_unc.min():.4f}  max={epi_unc.max():.4f}"
+          f"  mean={epi_unc.mean():.4f}")
+    print(f"[unc] aleatoric  min={ale_unc.min():.4f}  max={ale_unc.max():.4f}"
+          f"  mean={ale_unc.mean():.4f}")
+
+    # ── live viz ──────────────────────────────────────────────────────────
+    palette = plt.cm.tab10(np.linspace(0.0, 0.5, E))
+    fig, ax_he, ax_ha, ax_ts, ax_mu, ax_sig = make_figure(E)
+
+    print(f"[viz] animating {T_} frames (redraw every {args.update_every} steps)...")
+    for t in range(T_):
+        if t % args.update_every == 0 or t == T_ - 1:
+            update_figure(fig, ax_he, ax_ha, ax_ts, ax_mu, ax_sig,
+                          t, head_mu, head_sig, epi_unc, ale_unc, palette, E)
+            plt.pause(args.pause)
+
+    plt.ioff()
+    print("[viz] done — close the window to exit.")
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/run_uncertainty_viz.py
+++ b/run_uncertainty_viz.py
@@ -366,3 +366,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+# run_uncertainty_viz.py --checkpoint checkpoints_paws/model_2000_pretrain.pt --data utils_paws/walk_spot2.npz --device cpu --pause 0.05 --update_every 10

--- a/utils_paws/to_npz.py
+++ b/utils_paws/to_npz.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Convert a go2_data_recorder .bin file to a .npz file.
+
+Frame layout (236 bytes, packed, matches C++ struct Frame):
+  double  timestamp       [1]
+  float   obs[45]         [45]
+    obs[0:3]   base linear velocity   (m/s)
+    obs[3:6]   base angular velocity  (rad/s)
+    obs[6:9]   projected gravity
+    obs[9:21]  joint positions        (rad)
+    obs[21:33] joint velocities       (rad/s)
+    obs[33:45] joint torques          (Nm)
+  float   action[12]      [12]  commanded joint positions (rad)
+
+Usage:
+  python3 to_npz.py walk1.bin
+  python3 to_npz.py walk1.bin -o walk1.npz   # explicit output path
+"""
+
+import argparse
+import struct
+import sys
+import numpy as np
+from pathlib import Path
+
+JOINT_NAMES = [
+    "FR_Hip", "FR_Thigh", "FR_Calf",
+    "FL_Hip", "FL_Thigh", "FL_Calf",
+    "RR_Hip", "RR_Thigh", "RR_Calf",
+    "RL_Hip", "RL_Thigh", "RL_Calf",
+]
+
+# struct Frame { double ts; float obs[45]; float action[12]; }
+FRAME_FMT  = "<d45f12f"
+FRAME_SIZE = struct.calcsize(FRAME_FMT)
+assert FRAME_SIZE == 236, f"Frame size mismatch: {FRAME_SIZE}"
+
+
+def load_bin(path: str):
+    with open(path, "rb") as f:
+        n_bytes = f.read(8)
+        if len(n_bytes) < 8:
+            sys.exit("File too short — not a valid recording.")
+        (n,) = struct.unpack("<Q", n_bytes)
+        print(f"  frames declared : {n}")
+
+        raw = f.read(n * FRAME_SIZE)
+
+    actual = len(raw) // FRAME_SIZE
+    if actual < n:
+        print(f"  WARNING: only {actual} complete frames found (expected {n}), truncating.")
+        n = actual
+
+    timestamps = np.empty(n, dtype=np.float64)
+    obs        = np.empty((n, 45), dtype=np.float32)
+    actions    = np.empty((n, 12), dtype=np.float32)
+
+    for i in range(n):
+        chunk = raw[i * FRAME_SIZE : (i + 1) * FRAME_SIZE]
+        vals  = struct.unpack_from(FRAME_FMT, chunk)
+        timestamps[i] = vals[0]
+        obs[i]        = vals[1:46]
+        actions[i]    = vals[46:58]
+
+    return timestamps, obs, actions
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Convert .bin recording to .npz")
+    ap.add_argument("bin_file", help="Input .bin file")
+    ap.add_argument("-o", "--output", default=None, help="Output .npz path")
+    args = ap.parse_args()
+
+    out_path = args.output or str(Path(args.bin_file).with_suffix(".npz"))
+
+    print(f"Loading {args.bin_file} ...")
+    timestamps, obs, actions = load_bin(args.bin_file)
+    n = len(timestamps)
+
+    duration = timestamps[-1] - timestamps[0] if n > 1 else 0.0
+    dt_mean  = duration / (n - 1) if n > 1 else 0.0
+    hz_mean  = 1.0 / dt_mean if dt_mean > 0 else 0.0
+
+    print(f"  frames loaded   : {n}")
+    print(f"  duration        : {duration:.2f} s")
+    print(f"  mean rate       : {hz_mean:.1f} Hz")
+
+    np.savez(
+        out_path,
+        timestamps        = timestamps,          # (N,)
+        obs               = obs,                 # (N, 45)
+        actions           = actions,             # (N, 12)
+        # convenient named slices
+        base_lin_vel      = obs[:, 0:3],         # (N, 3)
+        base_ang_vel      = obs[:, 3:6],         # (N, 3)
+        projected_gravity = obs[:, 6:9],         # (N, 3)
+        joint_pos         = obs[:, 9:21],        # (N, 12)
+        joint_vel         = obs[:, 21:33],       # (N, 12)
+        joint_torque      = obs[:, 33:45],       # (N, 12)
+    )
+    print(f"\nSaved -> {out_path}")
+    print("\nArrays inside the .npz:")
+    print(f"  timestamps        {timestamps.shape}   float64  seconds since epoch")
+    print(f"  obs               {obs.shape}  float32  full 45-dim observation")
+    print(f"  actions           {actions.shape}  float32  commanded joint positions")
+    print(f"  base_lin_vel      (N, 3)   float32  m/s")
+    print(f"  base_ang_vel      (N, 3)   float32  rad/s")
+    print(f"  projected_gravity (N, 3)   float32")
+    print(f"  joint_pos         (N,12)   float32  rad   order: {', '.join(JOINT_NAMES)}")
+    print(f"  joint_vel         (N,12)   float32  rad/s")
+    print(f"  joint_torque      (N,12)   float32  Nm")
+    print("\nTo load in Python:")
+    print(f"  data = np.load('{out_path}')")
+    print( "  joint_pos = data['joint_pos']   # shape (N, 12)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Description:**
Adds a real-time visualization tool for monitoring per-head epistemic and aleatoric uncertainty of SystemDynamicsEnsemble during MBPO imagination rollouts. The system is fully opt-in and non-blocking — zero impact on runs where it is not activated.

**Changes**
manager_based_mbrl_env.py — added an optional hook in imagination_step() after self.system_dynamics.forward(). When _uncertainty_hook_enabled = True, it runs a secondary per-head forward pass under torch.no_grad() and populates self._hook_data with epistemic [B], aleatoric [B], per_head_means [E, B, D], per_head_stds [E, B, D], and a step counter.
mbpo_on_policy_runner.py — two additions: (1) in learn() after prepare_imagination(), creates an mp.Queue(maxsize=5), launches the visualizer process, and sets _uncertainty_hook_enabled = True; (2) inside the for i loop in imagine(), sends _hook_data to the queue every 10 steps via put_nowait() — non-blocking, silently drops if queue is full.
rsl_rl/utils/uncertainty_visualizer.py (new file) — daemon process that reads from the queue and updates a 5-panel matplotlib figure in real time: histograms of epistemic/aleatoric uncertainty, a running time series of both, and per-head μ and σ for the first N state dimensions. Auto-killed when training exits.

**Design notes**

SystemDynamicsEnsemble is untouched; hook lives entirely in the env layer
daemon=True + put_nowait() + queue size cap ensure no training slowdown
Separate process (not thread) to avoid matplotlib/GIL conflicts with existing Plotter